### PR TITLE
feat(executor): add needs_retry status and resume/retry support

### DIFF
--- a/src/cli/run_dashboard.py
+++ b/src/cli/run_dashboard.py
@@ -209,6 +209,7 @@ _STATUS_DECOR: dict[str, tuple[str, str, str]] = {
     "running":    ("▸",   "magenta",      "magenta"),
     "done":       ("✓",   "bold green",   "green"),
     "merged":     ("↻",   "bold green",   "bold green"),
+    "needs_retry":("⟳",   "bold yellow",  "yellow"),
     "pruned":     ("✗",   "bright_black", "bright_black"),
     "failed":     ("!",   "bold red",     "red"),
 }
@@ -1606,6 +1607,7 @@ class RunDashboard:
             f"[bold]ideas {s.ideas_proposed}[/]  "
             f"[green]✓{s.ideas_done}[/] "
             f"[bright_black]✗{s.ideas_pruned}[/] "
+            f"[yellow]⟳{s.ideas_needs_retry}[/] "
             f"[magenta]▸{s.ideas_running}[/]"
         )
         direction_glyph = "↓" if s.metric_direction == "minimize" else "↑"
@@ -2622,6 +2624,8 @@ def _format_idea_metric(
         return Text(_short(rec.pruned_reason or "—", 10), style="bright_black")
     if rec.status == "failed":
         return Text("failed", style="red")
+    if rec.status == "needs_retry":
+        return Text("retry", style="yellow")
     return Text("")
 
 

--- a/src/cli/run_state.py
+++ b/src/cli/run_state.py
@@ -113,6 +113,7 @@ class RunState:
     ideas_pruned: int = 0
     ideas_merged: int = 0
     ideas_running: int = 0
+    ideas_needs_retry: int = 0
     best_score: float | None = None
     metric_direction: str = "maximize"
     baseline_score: float | None = None
@@ -537,7 +538,7 @@ class RunState:
             rec.score = float(score)
             self._bump_best(score)
         status = (d.get("status") or "done").lower()
-        rec.status = status if status in ("done", "failed") else "done"
+        rec.status = status if status in ("done", "failed", "needs_retry") else "done"
         rec.finished_at = time.monotonic()
         self._recount()
         self.mark_dirty()
@@ -599,7 +600,11 @@ class RunState:
             rec.score = float(score)
             self._bump_best(score)
         if rec.status == "running":
-            rec.status = "done"     # provisional until completed event lands
+            # Provisional until the completed event lands. The executor reports
+            # its classified outcome on EXECUTOR_END, so honour it when present
+            # (avoids briefly showing a needs_retry node as "done").
+            ev_status = (d.get("status") or "").lower()
+            rec.status = ev_status if ev_status in ("done", "needs_retry", "failed") else "done"
         rec.finished_at = time.monotonic()
         if self.current_idea_node == node:
             self.current_idea_node = None
@@ -674,7 +679,7 @@ class RunState:
     def _recount(self) -> None:
         """Recompute the small idea counters from the ledger so the
         header stays consistent without us tracking deltas by hand."""
-        c = {"running": 0, "done": 0, "merged": 0, "pruned": 0, "failed": 0}
+        c = {"running": 0, "done": 0, "merged": 0, "pruned": 0, "failed": 0, "needs_retry": 0}
         for rec in self.ideas.values():
             if rec.status in c:
                 c[rec.status] += 1
@@ -683,6 +688,7 @@ class RunState:
         self.ideas_done = c["done"] + c["merged"]   # both count toward "completed"
         self.ideas_pruned = c["pruned"] + c["failed"]
         self.ideas_merged = c["merged"]
+        self.ideas_needs_retry = c["needs_retry"]   # incomplete — its own bucket
 
     def seed_from_tree(self, tree_data: dict[str, Any]) -> None:
         """Rehydrate the idea ledger from a persisted idea tree (for --resume).
@@ -781,7 +787,9 @@ class RunState:
 
     @property
     def branch_budget_used(self) -> int:
-        return self.ideas_done + self.ideas_pruned
+        # Must mirror _CYCLE_STATUSES (executor_run.py): done/merged/pruned/failed
+        # AND needs_retry all consume a cycle toward max_cycles.
+        return self.ideas_done + self.ideas_pruned + self.ideas_needs_retry
 
 
 # ── module-level current state ─────────────────────────────────────

--- a/src/coordinator/config.py
+++ b/src/coordinator/config.py
@@ -358,6 +358,10 @@ class CoordinatorConfig(ProxyModel):
 
     # ── Executor parameters ──────────────────────────────────────────
     executor_max_turns: int = 50
+    # Max resume attempts (retries beyond the initial run) before ResumeExecutor
+    # refuses to continue a node. Each resume increments node.attempt; bounds
+    # runaway resume loops.
+    max_retries: int = 3
 
     # ── Evaluation ───────────────────────────────────────────────────
     merge_threshold: float = 5.0  # soft guideline for the LLM

--- a/src/coordinator/idea_tree.py
+++ b/src/coordinator/idea_tree.py
@@ -18,7 +18,7 @@ from typing import Any, ClassVar, Literal
 
 log = logging.getLogger(__name__)
 
-NodeStatus = Literal["pending", "running", "done", "merged", "pruned"]
+NodeStatus = Literal["pending", "running", "done", "needs_retry", "merged", "pruned"]
 
 
 # ---------------------------------------------------------------------------
@@ -43,6 +43,13 @@ class Node:
     code_ref: str | None = None  # Git branch name
     related_work: str = ""  # SearchAgent / web-search annotation (Markdown)
 
+    # Outcome metadata (set when an executor finishes). eval_status classifies
+    # why there is/isn't a score; stop_reason mirrors Agent.stop_reason; attempt
+    # counts dispatches (incremented by ResumeExecutor). See _classify_executor_outcome.
+    eval_status: str | None = None  # "scored" | "skipped" | "failed_to_run"
+    stop_reason: str | None = None  # "finished" | "max_turns" | None
+    attempt: int = 1  # 1 for the first run, +1 per resume
+
     # Fields that may be mutated via update_node / async_update_node.
     # Centralised so the whitelist lives in one place.
     MUTABLE_FIELDS: ClassVar[frozenset[str]] = frozenset({
@@ -53,6 +60,9 @@ class Node:
         "score",
         "code_ref",
         "related_work",
+        "eval_status",
+        "stop_reason",
+        "attempt",
     })
 
     def to_dict(self) -> dict[str, Any]:
@@ -74,6 +84,12 @@ class Node:
             d["code_ref"] = self.code_ref
         if self.related_work:
             d["related_work"] = self.related_work
+        if self.eval_status:
+            d["eval_status"] = self.eval_status
+        if self.stop_reason:
+            d["stop_reason"] = self.stop_reason
+        if self.attempt and self.attempt != 1:
+            d["attempt"] = self.attempt
         return d
 
     @classmethod
@@ -90,6 +106,9 @@ class Node:
             score=data.get("score", data.get("score_delta")),  # backward compat
             code_ref=data.get("code_ref"),
             related_work=data.get("related_work", ""),
+            eval_status=data.get("eval_status"),
+            stop_reason=data.get("stop_reason"),
+            attempt=data.get("attempt", 1),
         )
 
 
@@ -229,6 +248,10 @@ class IdeaTree:
         if "status" in updates:
             status = updates["status"]
             if status == "done":
+                # needs_retry is intentionally NOT a completion event — it is an
+                # incomplete outcome. Executor-originated transitions surface via
+                # EXECUTOR_END (which carries the status); manual ones update the
+                # tree and refresh on the next dashboard re-ingest.
                 from ..events.types import IDEA_COMPLETED
                 self.bus.emit(IDEA_COMPLETED, {
                     "node_id": node_id,

--- a/src/coordinator/prompts.py
+++ b/src/coordinator/prompts.py
@@ -380,7 +380,7 @@ the WRONG code and results will leak into the main repository.
 
 After INIT, repeat these steps until you run out of promising directions, \
 or until the hard cycle cap is hit (currently {config.max_cycles} — \
-RunExecutor will refuse once done+merged+pruned+failed nodes reach this \
+RunExecutor will refuse once done+merged+pruned+failed+needs_retry nodes reach this \
 number):
 
 ### Step 1: OBSERVE
@@ -405,6 +405,9 @@ Dispatch Executor(s) to implement and test ideas.
 - **Single idea**: Use RunExecutor(node_id, additional_context=...)
 - **Multiple ideas**: Use RunExecutorParallel(tasks=[...]) to explore \
 2-4 ideas simultaneously for faster iteration.
+- **Resume a stalled idea**: Use ResumeExecutor(node_id, extra_turns=...) on a \
+`needs_retry` node to continue its preserved branch with the prior report \
+injected (see Step 5).
 - Evaluation info (eval_cmd, scores, dataset_info) from tree metadata \
 is **automatically injected** into every Executor's prompt. You don't \
 need to repeat it in additional_context.
@@ -416,7 +419,10 @@ current trunk — it cannot interfere with other Executors or your trunk.
 - RunExecutor/RunExecutorParallel automatically:
   (a) Runs the executor on an isolated branch from trunk
   (b) Parses the report to extract score, insight, and code_ref
-  (c) Updates the tree node (status="done", score, insight, etc.)
+  (c) Updates the tree node: status="done" when a real score was produced \
+(or eval was intentionally skipped on solid work), otherwise \
+status="needs_retry" (timed out, hit max turns, or eval failed to run — \
+no parseable score). A "needs_retry" node is NOT a successful experiment.
   (d) Propagates insights up through the tree to the root
 - Review the returned summary to verify the auto-extracted results.
 - If the auto-extraction looks wrong, use TreeUpdateNode to correct it.
@@ -433,6 +439,11 @@ verifies the score before merging. You do NOT need to run B_test yourself.
   3. After a successful merge: update trunk_score via TreeSetMeta, then \
 TreeUpdateNode to set status="merged"
 - **prune**: a direction has failed → TreePrune
+- **retry**: a node is `needs_retry` (no score — timed out / hit max turns / \
+eval failed to run) → use ResumeExecutor(node_id, extra_turns=...) to continue \
+its preserved branch with the prior report injected, RunExecutor to retry from \
+trunk, or TreePrune to abandon it. Do NOT treat a `needs_retry` node as a \
+completed experiment.
 - **stop**: all directions explored or diminishing returns
 - Use TreePropagate manually if you update a node's insight via \
 TreeUpdateNode and want to re-propagate.

--- a/src/coordinator/tools/__init__.py
+++ b/src/coordinator/tools/__init__.py
@@ -14,7 +14,7 @@ from ...core.tools.skill import LoadSkillTool
 from ...core.skill_registry import build_default_registry
 
 from .tree_ops import TreeViewTool, TreeAddNodeTool, TreeUpdateNodeTool, TreePruneTool, TreeSetMetaTool, TreePropagateTool
-from .executor_run import RunExecutorTool, RunExecutorParallelTool
+from .executor_run import RunExecutorTool, RunExecutorParallelTool, ResumeExecutorTool
 from .git_ops import GitMergeBranchTool
 from .search_ctx import SearchIdeaContextTool, SearchIdeaContextParallelTool, SearchStatusTool
 from .ask_user import AskUserTool
@@ -63,6 +63,10 @@ def get_coordinator_tools(
             workspace_dir=wdir, convergence_detector=convergence_detector,
         ),
         RunExecutorParallelTool(
+            cwd=cwd, tree=tree, config=config, provider=provider,
+            workspace_dir=wdir, convergence_detector=convergence_detector,
+        ),
+        ResumeExecutorTool(
             cwd=cwd, tree=tree, config=config, provider=provider,
             workspace_dir=wdir, convergence_detector=convergence_detector,
         ),

--- a/src/coordinator/tools/executor_run.py
+++ b/src/coordinator/tools/executor_run.py
@@ -27,7 +27,7 @@ from .git_ops import _run_git
 
 if TYPE_CHECKING:
     from ..config import CoordinatorConfig
-    from ..idea_tree import IdeaTree
+    from ..idea_tree import IdeaTree, Node
     from ...core.llm.base import LLMProvider
 
 log = logging.getLogger(__name__)
@@ -38,7 +38,34 @@ log = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-_CYCLE_STATUSES = {"done", "merged", "pruned", "failed"}
+_CYCLE_STATUSES = {"done", "merged", "pruned", "failed", "needs_retry"}
+
+
+def _classify_executor_outcome(
+    *,
+    score: Any,
+    eval_status: str | None,
+    stop_reason: str | None,
+    raw_report: str,
+) -> str:
+    """Decide a node's terminal status from an executor run's outcome.
+
+    A node is only "done" when it produced a real metric, or when eval was
+    *intentionally* skipped on otherwise-complete work. Turn-cap / timeout /
+    error / eval-crash exits become "needs_retry" — an incomplete-but-not-
+    abandoned state that is excluded from every "completed experiment" filter
+    (best-node, convergence, reports) and can be resumed via ResumeExecutor.
+    """
+    if isinstance(score, (int, float)) and not isinstance(score, bool):
+        return "done"  # produced a metric — trust it even on a late stop
+    if raw_report.startswith("[Timed out") or raw_report.startswith("[Error:"):
+        return "needs_retry"
+    if stop_reason == "max_turns":
+        return "needs_retry"
+    if eval_status == "skipped":
+        return "done"  # intentional no-eval on solid work — acceptable
+    return "needs_retry"  # failed_to_run / unparseable report
+
 
 
 def _completed_cycles(tree: "IdeaTree") -> int:
@@ -63,6 +90,10 @@ async def _save_experiment_artifacts(
     parsed: dict[str, Any],
     actual_branch: str,
     agent_turns: int,
+    status: str = "done",
+    eval_status: str | None = None,
+    stop_reason: str | None = None,
+    attempt: int = 1,
 ) -> None:
     """Save per-experiment artifacts to the workspace experiments/ directory."""
     workspace = config.workspace_dir
@@ -76,6 +107,11 @@ async def _save_experiment_artifacts(
         f"# Experiment {node_id}\n\n"
         f"**Hypothesis**: {hypothesis}\n"
         f"**Branch**: `{actual_branch}`\n"
+        f"**Attempt**: {attempt}\n"
+        f"**Status**: {status}\n"
+        f"**Eval status**: {eval_status or 'unknown'}"
+        + (f" (stop_reason={stop_reason})" if stop_reason else "")
+        + "\n"
         f"**Turns**: {agent_turns}\n\n"
         f"---\n\n"
         f"{raw_report}\n"
@@ -90,6 +126,10 @@ async def _save_experiment_artifacts(
         "result": parsed.get("result", ""),
         "branch": actual_branch,
         "turns": agent_turns,
+        "status": status,
+        "eval_status": eval_status,
+        "stop_reason": stop_reason,
+        "attempt": attempt,
     }
     (exp_dir / "metrics.json").write_text(
         json.dumps(metrics, indent=2, ensure_ascii=False), encoding="utf-8",
@@ -106,6 +146,61 @@ async def _save_experiment_artifacts(
             config.cwd,
         )
         (exp_dir / "diff.patch").write_text(full_diff, encoding="utf-8")
+
+
+def _build_resume_context(
+    config: "CoordinatorConfig", node: "Node", attempt: int
+) -> str | None:
+    """Assemble context for a resumed attempt from the prior attempt's artifacts.
+
+    The executor worktree is gone, but its branch (``node.code_ref``) is checked
+    out as this attempt's start point, so the code is already present. This block
+    re-grounds the model on what the last attempt did, where it stopped, and the
+    shape of its diff — without replaying the (discarded) message history.
+    """
+    parts: list[str] = [
+        f"## Resuming a prior attempt (attempt {attempt})",
+        (
+            f"A previous executor on this idea ended as `{node.status}` "
+            f"(eval_status={node.eval_status or 'unknown'}"
+            + (f", stop_reason={node.stop_reason}" if node.stop_reason else "")
+            + "). "
+            + (
+                f"Its committed work is already on this worktree's branch "
+                f"`{node.code_ref}` — continue from there; do NOT start over. "
+                if node.code_ref
+                else "Its work was not committed, so you are starting from trunk; "
+                "use the prior report below to avoid repeating dead ends. "
+            )
+            + "Finish the implementation and run the evaluation so a real score "
+            "is produced."
+        ),
+    ]
+    if node.result:
+        parts.append(f"### Prior result\n{node.result.strip()}")
+    if node.insight:
+        parts.append(f"### Prior insight\n{node.insight.strip()}")
+
+    workspace = config.workspace_dir
+    if workspace:
+        exp_dir = Path(workspace) / "experiments" / node.id
+        report = exp_dir / "report.md"
+        diff = exp_dir / "diff.patch"
+        if report.exists():
+            text = report.read_text(encoding="utf-8", errors="replace")
+            parts.append(f"### Prior report (truncated)\n{_tail(text, 6000)}")
+        if diff.exists():
+            text = diff.read_text(encoding="utf-8", errors="replace")
+            parts.append(f"### Prior diff --stat / patch (truncated)\n{_tail(text, 4000)}")
+    return "\n\n".join(parts)
+
+
+def _tail(text: str, limit: int) -> str:
+    """Return the last ``limit`` chars of ``text`` with a truncation marker."""
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return f"[... truncated to last {limit} chars ...]\n" + text[-limit:]
 
 
 # ---------------------------------------------------------------------------
@@ -391,6 +486,11 @@ async def _parse_executor_report(
             '- "insight": string (key learning, 1-3 sentences)\n'
             '- "result": string (factual description, 1-2 sentences)\n'
             '- "code_ref": string or null (git branch name if mentioned)\n'
+            '- "eval_status": one of "scored" (a numeric metric was produced by '
+            "running evaluation), \"skipped\" (implementation looks complete but "
+            "evaluation was intentionally not run), or \"failed_to_run\" "
+            "(evaluation was attempted but crashed/produced no parseable metric, "
+            "or there was no working implementation)\n"
             "No markdown fencing. Just raw JSON."
         ),
         messages=[
@@ -426,7 +526,13 @@ async def _parse_executor_report(
         return json.loads(text)
     except json.JSONDecodeError:
         log.warning("Failed to parse JSON from LLM response: %s", text[:200])
-        return {"score": None, "insight": "", "result": text[:500], "code_ref": None}
+        return {
+            "score": None,
+            "insight": "",
+            "result": text[:500],
+            "code_ref": None,
+            "eval_status": "failed_to_run",
+        }
 
 
 async def _run_after_executor_hook(
@@ -466,10 +572,17 @@ async def _run_single_executor(
     provider: "LLMProvider",
     node_id: str,
     additional_context: str | None = None,
+    resume: bool = False,
+    extra_turns: int = 0,
 ) -> str:
     """Run one executor in an isolated git worktree.
 
     Handles the full lifecycle: validate → worktree → run → parse → update tree.
+
+    When ``resume`` is set, the worktree branches from the node's preserved
+    ``code_ref`` (the prior attempt's committed work) instead of trunk, the turn
+    budget is raised by ``extra_turns``, and the prior attempt's report/diff are
+    injected as context (see ResumeExecutor).
     """
     # ── Early stop: gold already achieved ──────────────────────────
     if tree.meta.get("achieved_medal") == "gold":
@@ -488,11 +601,14 @@ async def _run_single_executor(
     node = tree.get_node(node_id)
     if node is None:
         return f"Error: Node {node_id!r} not found in the idea tree."
-    if node.status not in ("pending", "running"):
+    if node.status not in ("pending", "running", "needs_retry"):
         return (
             f"Error: Node {node_id} has status={node.status!r}. "
-            f"Only 'pending' nodes can be dispatched."
+            f"Only 'pending' or 'needs_retry' nodes can be dispatched."
         )
+
+    # Attempt number for this dispatch (1 for the first run, +1 per resume).
+    attempt = node.attempt + 1 if resume else node.attempt
 
     # ── 1b. Enforce leaf-only dispatch when max_depth is set ───────────
     if tree.max_depth is not None and node.depth < tree.max_depth:
@@ -513,15 +629,24 @@ async def _run_single_executor(
     })
 
     # ── 3. Create worktree ──────────────────────────────────────────────
+    # On resume, continue the prior attempt's branch so its committed code is
+    # the starting point; otherwise branch fresh from trunk. The attempt suffix
+    # keeps each resume on its own auditable branch.
+    resume_from = node.code_ref if (resume and node.code_ref) else None
     branch_name = _compute_branch_name(config, node_id, node.hypothesis)
+    if resume_from:
+        branch_name = f"{branch_name}-a{attempt}"
+    start_point = resume_from or config.trunk_branch
     worktree_path: Path | None = None
     actual_branch = branch_name
 
     try:
         worktree_path, actual_branch = await _create_worktree(
-            config.cwd, branch_name, start_point=config.trunk_branch,
+            config.cwd, branch_name, start_point=start_point,
         )
     except RuntimeError as e:
+        # Worktree setup failed before anything ran — no compute spent, so keep
+        # it re-dispatchable (pending) rather than consuming a cycle as needs_retry.
         await tree.async_update_node(node_id, status="pending", result=f"Worktree creation failed: {e}")
         return f"Error creating worktree for {node_id}: {e}"
     tree.bus.emit(ev.EXECUTOR_START, {
@@ -534,6 +659,7 @@ async def _run_single_executor(
     # ── 4. Build executor ───────────────────────────────────────────────
     raw_report = ""
     agent_turns = 0
+    stop_reason: str | None = None
     agent: Agent | None = None
     executor_t0 = asyncio.get_running_loop().time()
 
@@ -541,6 +667,8 @@ async def _run_single_executor(
         executor_config = config.to_executor_config(node_id, node.hypothesis)
         executor_config.cwd = str(worktree_path)
         executor_config.event_bus = tree.bus
+        if resume and extra_turns:
+            executor_config.max_turns += extra_turns
 
         system_prompt = build_system_prompt(executor_config, plugin=config.plugin)
         tools = get_all_tools(
@@ -572,12 +700,16 @@ async def _run_single_executor(
             worktree_cwd=str(worktree_path),
             node_id=node_id,
         )
+        merged_context = additional_context
+        if resume:
+            prior = _build_resume_context(config, node, attempt)
+            merged_context = "\n\n".join(c for c in (prior, additional_context) if c)
         prompt = _build_executor_prompt(
             worktree_path=worktree_path,
             node=node,
             ancestor_insights=ancestor_insights,
             eval_info=eval_info,
-            additional_context=additional_context,
+            additional_context=merged_context,
         )
 
         log.info(
@@ -592,14 +724,17 @@ async def _run_single_executor(
         )
         raw_report = result
         agent_turns = agent.total_turns
+        stop_reason = agent.stop_reason
 
     except asyncio.TimeoutError:
         agent_turns = agent.total_turns if agent is not None else 0
+        stop_reason = agent.stop_reason if agent is not None else None
         raw_report = f"[Timed out after {config.executor_timeout}s]"
         log.warning("Executor for %s timed out after %ds", node_id, config.executor_timeout)
 
     except Exception as e:
         agent_turns = agent.total_turns if agent is not None else 0
+        stop_reason = agent.stop_reason if agent is not None else None
         raw_report = f"[Error: {e}]"
         log.error("Executor for %s failed: %s", node_id, e)
 
@@ -635,15 +770,27 @@ async def _run_single_executor(
     insight = parsed.get("insight", "")
     result_text = parsed.get("result", "")
     code_ref = parsed.get("code_ref") or actual_branch
+    eval_status = parsed.get("eval_status", "failed_to_run")
 
     # ── 9. Update tree node ─────────────────────────────────────────────
+    # Only a real score (or an intentionally-skipped eval on solid work) counts
+    # as "done"; turn-cap / timeout / error / eval-crash become "needs_retry".
+    new_status = _classify_executor_outcome(
+        score=score,
+        eval_status=eval_status,
+        stop_reason=stop_reason,
+        raw_report=raw_report,
+    )
     await tree.async_update_node(
         node_id,
-        status="done",
+        status=new_status,
         score=score,
         insight=insight or ("Timed out" if raw_report.startswith("[Timed out") else ""),
         result=result_text or raw_report[:300],
         code_ref=code_ref,
+        eval_status=eval_status,
+        stop_reason=stop_reason,
+        attempt=attempt,
     )
     duration = max(0.0, asyncio.get_running_loop().time() - executor_t0)
     tree.bus.emit(ev.EXECUTOR_END, {
@@ -656,6 +803,7 @@ async def _run_single_executor(
         ),
         "turns": agent_turns,
         "branch": code_ref,
+        "status": new_status,
     })
     tree.bus.emit(ev.CYCLE_END, {
         "cycle_num": cycle_num,
@@ -674,6 +822,10 @@ async def _run_single_executor(
             parsed=parsed,
             actual_branch=actual_branch,
             agent_turns=agent_turns,
+            status=new_status,
+            eval_status=eval_status,
+            stop_reason=stop_reason,
+            attempt=attempt,
         )
     except Exception as e:
         log.warning("Failed to save experiment artifacts for %s: %s", node_id, e)
@@ -698,16 +850,29 @@ async def _run_single_executor(
             + raw_report[-4000:]
         )
 
+    retry_hint = ""
+    if new_status == "needs_retry":
+        retry_hint = (
+            "\n\n> This node is **needs_retry** (no score — "
+            f"{eval_status}"
+            + (f", stop_reason={stop_reason}" if stop_reason else "")
+            + "). The branch above preserves its committed work. To continue it "
+            "with extra turns and the prior report injected, call "
+            f"`ResumeExecutor(node_id={node_id!r})`; or `RunExecutor` to retry "
+            "from trunk, or `TreePrune` to abandon."
+        )
+
     return (
         f"## Executor Result for {node_id}\n\n"
         f"**Hypothesis**: {node.hypothesis}\n"
-        f"**Status**: done (auto-updated)\n"
+        f"**Status**: {new_status} (attempt {attempt})\n"
         f"**Score**: {score_str}\n"
         f"**Insight**: {insight}\n"
         f"**Branch**: `{code_ref}`\n"
         f"**Turns**: {agent_turns}\n\n"
         f"### Propagation\n{propagation_result}\n\n"
         f"### Report Excerpt\n\n{report_excerpt}"
+        f"{retry_hint}"
     )
 
 
@@ -772,7 +937,11 @@ class RunExecutorTool(Tool):
         "properties": {
             "node_id": {
                 "type": "string",
-                "description": "The idea node ID to implement (must be 'pending').",
+                "description": (
+                    "The idea node ID to implement (must be 'pending' or "
+                    "'needs_retry'; a 'needs_retry' node restarts from trunk — "
+                    "use ResumeExecutor to continue its preserved branch instead)."
+                ),
             },
             "additional_context": {
                 "type": "string",
@@ -810,7 +979,7 @@ class RunExecutorTool(Tool):
         if done >= cap:
             return (
                 f"HARD LIMIT REACHED: {done}/{cap} cycles already consumed "
-                f"(counting done/merged/pruned/failed). RunExecutor is disabled. "
+                f"(counting done/merged/pruned/failed/needs_retry). RunExecutor is disabled. "
                 f"Finalize now: merge the best branch if it beats the threshold, "
                 f"otherwise stop and report."
             )
@@ -845,9 +1014,97 @@ class RunExecutorTool(Tool):
         return result
 
 
-# ---------------------------------------------------------------------------
-# Tool: RunExecutorParallel (batch dispatch)
-# ---------------------------------------------------------------------------
+class ResumeExecutorTool(RunExecutorTool):
+    """Resume a ``needs_retry`` node, continuing its preserved branch.
+
+    Unlike RunExecutor (which would restart from trunk), this continues from the
+    node's ``code_ref`` branch — the prior attempt's committed work — with extra
+    turns and the prior report/diff injected as context. Use it when an executor
+    timed out, hit its turn cap, or failed to produce a score, and the partial
+    work is worth finishing rather than discarding.
+    """
+
+    name = "ResumeExecutor"
+    description = (
+        "Resume a 'needs_retry' idea node: continue from its preserved branch "
+        "(the prior attempt's committed work) with extra turns and the prior "
+        "report/diff injected as context, so the executor finishes the work and "
+        "produces a real score instead of starting over.\n\n"
+        "Use when a node is 'needs_retry' (timed out / hit max turns / eval "
+        "failed to run) and the partial work is worth continuing. To retry from "
+        "scratch instead, use RunExecutor; to abandon, use TreePrune."
+    )
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "node_id": {
+                "type": "string",
+                "description": "The 'needs_retry' idea node ID to resume.",
+            },
+            "extra_turns": {
+                "type": "integer",
+                "description": "Extra turns added to the executor's budget (default 10).",
+            },
+            "additional_context": {
+                "type": "string",
+                "description": (
+                    "Extra steering for the resumed attempt (optional). The prior "
+                    "report/diff and eval info are injected automatically."
+                ),
+            },
+        },
+        "required": ["node_id"],
+    }
+
+    async def execute(self, **kwargs: Any) -> str:
+        node_id = kwargs["node_id"]
+        node = self._tree.get_node(node_id)
+        if node is None:
+            return f"Error: Node {node_id!r} not found in the idea tree."
+        if node.status != "needs_retry":
+            return (
+                f"Error: ResumeExecutor only applies to 'needs_retry' nodes; "
+                f"{node_id} is {node.status!r}. Use RunExecutor for a fresh dispatch."
+            )
+        if not node.code_ref:
+            return (
+                f"Error: Node {node_id} has no preserved branch (code_ref is None) — "
+                f"the prior attempt likely crashed before committing any work, so "
+                f"there is nothing to continue. Use RunExecutor to retry from trunk."
+            )
+        # node.attempt counts completed dispatches (1 = initial run); max_retries
+        # is retries beyond that, so allow while attempt <= max_retries.
+        max_retries = getattr(self._config, "max_retries", 3)
+        if node.attempt > max_retries:
+            return (
+                f"Error: Node {node_id} has already used {node.attempt - 1} of "
+                f"{max_retries} allowed retries. Prune it or accept the result "
+                f"instead of resuming again."
+            )
+        done = _completed_cycles(self._tree)
+        cap = self._config.max_cycles
+        if done >= cap:
+            return (
+                f"HARD LIMIT REACHED: {done}/{cap} cycles already consumed. "
+                f"ResumeExecutor is disabled. Finalize now."
+            )
+        result = await _run_single_executor(
+            tree=self._tree,
+            config=self._config,
+            provider=self._provider,
+            node_id=node_id,
+            additional_context=kwargs.get("additional_context"),
+            resume=True,
+            extra_turns=int(kwargs.get("extra_turns", 10) or 10),
+        )
+        if self._convergence_detector:
+            signal = self._convergence_detector.on_experiment_complete(node_id)
+            if signal:
+                intervention = self._convergence_detector.format_intervention(signal)
+                result += f"\n\n---\n{intervention}\n---"
+                if signal.level == "stop":
+                    self._convergence_detector.write_stop_signal(self._config.workspace_dir)
+        return result
 
 class RunExecutorParallelTool(Tool):
     """Dispatch multiple executors in parallel, each in its own git worktree."""
@@ -942,7 +1199,7 @@ class RunExecutorParallelTool(Tool):
         if remaining <= 0:
             return (
                 f"HARD LIMIT REACHED: {done}/{cap} cycles already consumed "
-                f"(counting done/merged/pruned/failed). RunExecutorParallel is "
+                f"(counting done/merged/pruned/failed/needs_retry). RunExecutorParallel is "
                 f"disabled. Finalize now: merge the best branch if it beats the "
                 f"threshold, otherwise stop and report."
             )
@@ -960,9 +1217,10 @@ class RunExecutorParallelTool(Tool):
             node = self._tree.get_node(task["node_id"])
             if node is None:
                 errors.append(f"Node {task['node_id']!r} not found.")
-            elif node.status != "pending":
+            elif node.status not in ("pending", "needs_retry"):
                 errors.append(
-                    f"Node {task['node_id']} has status={node.status!r}, expected 'pending'."
+                    f"Node {task['node_id']} has status={node.status!r}, "
+                    f"expected 'pending' or 'needs_retry'."
                 )
             elif (
                 self._tree.max_depth is not None

--- a/src/coordinator/tools/tree_ops.py
+++ b/src/coordinator/tools/tree_ops.py
@@ -246,8 +246,11 @@ class TreeUpdateNodeTool(Tool):
             },
             "status": {
                 "type": "string",
-                "enum": ["pending", "running", "done", "merged", "pruned"],
-                "description": "New status.",
+                "enum": ["pending", "running", "done", "needs_retry", "merged", "pruned"],
+                "description": (
+                    "New status. Use 'needs_retry' for an incomplete/unscored "
+                    "attempt that should be resumed or retried (it is NOT a success)."
+                ),
             },
             "insight": {
                 "type": "string",

--- a/src/core/agent.py
+++ b/src/core/agent.py
@@ -208,6 +208,12 @@ class Agent:
         self.config = config
         self.messages: list[dict[str, Any]] = []
         self.total_turns = 0
+        # Why the loop exited, surfaced to callers alongside total_turns:
+        #   "finished"  — model produced a final answer with no tool calls
+        #   "max_turns" — exhausted the turn budget without a final answer
+        # Stays None if the run was cancelled mid-loop (e.g. timeout), since the
+        # coroutine never reaches a return. Callers detect that case otherwise.
+        self.stop_reason: str | None = None
         self.total_input_tokens = 0
         self.total_uncached_input_tokens = 0
         self.total_cache_read_tokens = 0
@@ -412,6 +418,7 @@ class Agent:
                     f"Done after {turn} turns ({reason}). "
                     f"Tokens: {self.total_input_tokens} in / {self.total_output_tokens} out"
                 )
+                self.stop_reason = "finished"
                 return text
 
             no_tool_nudges = 0
@@ -432,6 +439,7 @@ class Agent:
             })
 
         _print_status(f"Reached max turns ({self.config.max_turns}).")
+        self.stop_reason = "max_turns"
         return f"Agent stopped after {self.config.max_turns} turns without a final answer."
 
     # ------------------------------------------------------------------

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -87,6 +87,7 @@ _STATUS_COLORS = {
     "merged": "#22c55e",
     "done": "#3b82f6",
     "running": "#f59e0b",
+    "needs_retry": "#eab308",
     "pending": "#a3a3a3",
     "pruned": "#6b7280",
 }
@@ -95,6 +96,7 @@ _STATUS_BG = {
     "merged": "#dcfce7",
     "done": "#dbeafe",
     "running": "#fef3c7",
+    "needs_retry": "#fef9c3",
     "pending": "#f5f5f5",
     "pruned": "#f3f4f6",
 }

--- a/src/events/subscribers/cli_logger.py
+++ b/src/events/subscribers/cli_logger.py
@@ -160,6 +160,7 @@ def _on_idea_completed(e: Event) -> None:
     glyph_style = {
         "merged": "bold green",
         "done":   "bold cyan",
+        "needs_retry": "bold yellow",
         "failed": "bold red",
         "pruned": "bright_black",
     }.get(status, "cyan")

--- a/src/webui/snapshot.py
+++ b/src/webui/snapshot.py
@@ -144,6 +144,7 @@ def state_to_dict(s: Any) -> dict[str, Any]:
             "pruned": s.ideas_pruned,
             "merged": s.ideas_merged,
             "running": s.ideas_running,
+            "needs_retry": s.ideas_needs_retry,
         },
         "best_score": s.best_score,
         "baseline_score": s.baseline_score,

--- a/tests/test_executor_resume.py
+++ b/tests/test_executor_resume.py
@@ -1,0 +1,99 @@
+"""Unit tests for executor resume/retry status correctness.
+
+The repo ships no test harness, so this file is self-contained: run it directly
+with any Python 3.10+ that can import the ``arbor`` package
+(``python tests/test_executor_resume.py``), or collect it with pytest. It maps
+the ``arbor`` package onto ``src/`` itself so no install step is required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+if "arbor" not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(
+        "arbor", _ROOT / "src" / "__init__.py",
+        submodule_search_locations=[str(_ROOT / "src")],
+    )
+    _arbor = importlib.util.module_from_spec(_spec)
+    sys.modules["arbor"] = _arbor
+    _spec.loader.exec_module(_arbor)
+
+from arbor.coordinator.idea_tree import Node  # noqa: E402
+from arbor.coordinator.tools.executor_run import (  # noqa: E402
+    _CYCLE_STATUSES,
+    _classify_executor_outcome,
+)
+
+
+def test_needs_retry_consumes_a_cycle() -> None:
+    # A timed-out/errored attempt spent compute, so it must spend budget —
+    # otherwise a perpetually-failing node never hits max_cycles.
+    assert "needs_retry" in _CYCLE_STATUSES
+
+
+def test_classifier_table() -> None:
+    cases = [
+        # A real metric is "done" even on a late stop or a contradictory eval_status.
+        (dict(score=45.2, eval_status="scored", stop_reason="finished", raw_report="ok"), "done"),
+        (dict(score=0.0, eval_status="scored", stop_reason="max_turns", raw_report="ok"), "done"),
+        (dict(score=12.0, eval_status="failed_to_run", stop_reason="finished", raw_report="ok"), "done"),
+        # No score + turn cap / timeout / error → needs_retry.
+        (dict(score=None, eval_status="failed_to_run", stop_reason="max_turns", raw_report="x"), "needs_retry"),
+        (dict(score=None, eval_status="scored", stop_reason=None, raw_report="[Timed out after 1s]"), "needs_retry"),
+        (dict(score=None, eval_status="scored", stop_reason=None, raw_report="[Error: boom]"), "needs_retry"),
+        # Intentional skip on solid work is an acceptable terminal "done".
+        (dict(score=None, eval_status="skipped", stop_reason="finished", raw_report="impl done, eval skipped"), "done"),
+        # ...but a skip that also ran out of turns is conservative needs_retry
+        # (max_turns is checked before skipped — the work may be incomplete).
+        (dict(score=None, eval_status="skipped", stop_reason="max_turns", raw_report="skipped, then ran out"), "needs_retry"),
+        # Unparseable / eval crashed with a normal finish → needs_retry.
+        (dict(score=None, eval_status="failed_to_run", stop_reason="finished", raw_report="garbage"), "needs_retry"),
+        # A bool is not a numeric score.
+        (dict(score=True, eval_status="scored", stop_reason="finished", raw_report="ok"), "needs_retry"),
+    ]
+    for kw, expected in cases:
+        got = _classify_executor_outcome(**kw)
+        assert got == expected, f"{kw} -> {got!r}, expected {expected!r}"
+
+
+def test_node_roundtrip_new_fields() -> None:
+    n = Node(
+        id="1", parent_id="ROOT", status="needs_retry", score=None,
+        eval_status="failed_to_run", stop_reason="max_turns", attempt=2, code_ref="br",
+    )
+    d = n.to_dict()
+    assert d["status"] == "needs_retry"
+    assert d["eval_status"] == "failed_to_run"
+    assert d["stop_reason"] == "max_turns"
+    assert d["attempt"] == 2
+
+    n2 = Node.from_dict(d)
+    assert (n2.status, n2.eval_status, n2.stop_reason, n2.attempt) == (
+        "needs_retry", "failed_to_run", "max_turns", 2,
+    )
+
+
+def test_node_backcompat_defaults() -> None:
+    # Old tree JSON lacks the new keys — they default, and to_dict omits them
+    # so existing readers and diffs stay clean.
+    old = {"id": "2", "parent_id": "ROOT", "status": "done", "score": 5.0}
+    o = Node.from_dict(old)
+    assert o.attempt == 1
+    assert o.eval_status is None
+    assert o.stop_reason is None
+    d = o.to_dict()
+    assert "attempt" not in d
+    assert "eval_status" not in d
+    assert "stop_reason" not in d
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")

--- a/tests/test_executor_resume_integration.py
+++ b/tests/test_executor_resume_integration.py
@@ -1,0 +1,385 @@
+"""Integration tests for the executor resume/retry lifecycle.
+
+These exercise ``_run_single_executor`` end-to-end with the heavy collaborators
+(the Agent, git worktree helpers, the report parser, insight propagation) mocked
+out, so the status-classification, attempt-counter, resume-branch, and turn-bump
+wiring is verified for real — not just the pure helper functions.
+
+Self-contained: run directly (``python tests/test_executor_resume_integration.py``)
+or via pytest. Maps the ``arbor`` package onto ``src/`` so no install is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import inspect
+import json
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+if "arbor" not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(
+        "arbor", _ROOT / "src" / "__init__.py",
+        submodule_search_locations=[str(_ROOT / "src")],
+    )
+    _arbor = importlib.util.module_from_spec(_spec)
+    sys.modules["arbor"] = _arbor
+    _spec.loader.exec_module(_arbor)
+
+import arbor.core.agent as agent_mod  # noqa: E402
+import arbor.core.tools as tools_mod  # noqa: E402
+import arbor.core.tools.executor_tool as exectool_mod  # noqa: E402
+import arbor.executor.prompts as prompts_mod  # noqa: E402
+import arbor.coordinator.tools.executor_run as er  # noqa: E402
+from arbor.coordinator.config import CoordinatorConfig  # noqa: E402
+from arbor.coordinator.idea_tree import IdeaTree, Node  # noqa: E402
+
+
+# ── Fakes ───────────────────────────────────────────────────────────────────
+
+class _FakeGitManager:
+    def __init__(self):
+        self._initialized = False
+        self.branch_name = None
+        self.cwd = None
+
+
+class FakeAgent:
+    """Stands in for core.agent.Agent. Scripted via class attributes set per test."""
+
+    next_report = "Score: 45.2%\nLooks good."
+    next_turns = 5
+    next_stop_reason = "finished"
+    raise_timeout = False
+
+    def __init__(self, *, provider, tools, system_prompt, config):
+        self.config = config
+        self.tools = dict(tools) if tools else {}
+        self.git_manager = _FakeGitManager()
+        self.total_turns = 0
+        self.stop_reason = None
+        self.total_input_tokens = 10
+        self.total_output_tokens = 20
+
+    async def run(self, prompt):
+        if type(self).raise_timeout:
+            # Simulate the asyncio.wait_for timeout the dispatcher wraps run() in.
+            raise asyncio.TimeoutError()
+        self.total_turns = type(self).next_turns
+        self.stop_reason = type(self).next_stop_reason
+        return type(self).next_report
+
+
+class FakeExecutorTool:
+    name = "Executor"
+
+    def __init__(self, *, cwd, parent_agent, workspace_dir):
+        pass
+
+
+# ── Harness ─────────────────────────────────────────────────────────────────
+
+def _make_tree(node_status="pending", *, code_ref=None, attempt=1):
+    root = Node(id="ROOT", parent_id=None, depth=0, status="done")
+    tree = IdeaTree(root=root, json_path=None, md_path=None, max_depth=None)
+    child = Node(
+        id="1", parent_id="ROOT", depth=0, status=node_status,
+        hypothesis="use dropout", code_ref=code_ref, attempt=attempt,
+        result="prior partial result" if code_ref else "",
+    )
+    tree._nodes["1"] = child
+    root.children_ids.append("1")
+    return tree
+
+
+class _Recorder:
+    """Captures the kwargs the mocked collaborators were called with."""
+
+    def __init__(self):
+        self.create_kwargs = None
+        self.injected_context = None
+        self.executor_max_turns = None
+
+
+def _patches(rec, parsed):
+    """Context managers mocking every heavy collaborator of _run_single_executor."""
+
+    async def fake_create_worktree(cwd, branch_name, start_point=None):
+        rec.create_kwargs = {"branch_name": branch_name, "start_point": start_point}
+        return Path(tempfile.gettempdir()) / "fake-wt", branch_name
+
+    async def fake_noop(*a, **k):
+        return None
+
+    async def fake_parse(*a, **k):
+        return dict(parsed)
+
+    async def fake_propagate(*a, **k):
+        return ""
+
+    def fake_build_prompt(*, worktree_path, node, ancestor_insights, eval_info, additional_context):
+        rec.injected_context = additional_context
+        return "PROMPT"
+
+    class _CapturingAgent(FakeAgent):
+        def __init__(self, *, provider, tools, system_prompt, config):
+            super().__init__(provider=provider, tools=tools, system_prompt=system_prompt, config=config)
+            rec.executor_max_turns = config.max_turns
+
+    return [
+        patch.object(agent_mod, "Agent", _CapturingAgent),
+        patch.object(tools_mod, "get_all_tools", lambda **k: []),
+        patch.object(exectool_mod, "ExecutorTool", FakeExecutorTool),
+        patch.object(prompts_mod, "build_system_prompt", lambda cfg, plugin=None: "sys"),
+        patch.object(er, "_create_worktree", fake_create_worktree),
+        patch.object(er, "_finalize_worktree", fake_noop),
+        patch.object(er, "_remove_worktree", fake_noop),
+        patch.object(er, "_run_after_executor_hook", fake_noop),
+        patch.object(er, "_parse_executor_report", fake_parse),
+        patch.object(er, "propagate_insights", fake_propagate),
+        patch.object(er, "_build_executor_prompt", fake_build_prompt),
+        patch.object(er, "_gather_ancestor_insights", lambda *a, **k: ""),
+        patch.object(er, "_get_eval_info", lambda *a, **k: ""),
+    ]
+
+
+async def _run(tree, *, parsed, resume=False, extra_turns=0, executor_timeout=None):
+    rec = _Recorder()
+    cfg = CoordinatorConfig(cwd=".")
+    cfg.workspace_dir = None  # skip artifact writes + git diff
+    if executor_timeout is not None:
+        cfg.executor_timeout = executor_timeout
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _patches(rec, parsed):
+            stack.enter_context(p)
+        out = await er._run_single_executor(
+            tree=tree, config=cfg, provider=object(), node_id="1",
+            resume=resume, extra_turns=extra_turns,
+        )
+    return out, rec
+
+
+# ── Tests: classification through the real lifecycle ─────────────────────────
+
+def test_success_marks_done():
+    tree = _make_tree("pending")
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Score: 45.2%"
+    FakeAgent.next_stop_reason = "finished"
+    _, _ = asyncio.run(_run(tree, parsed={"score": 45.2, "eval_status": "scored", "insight": "i", "result": "r"}))
+    n = tree.get_node("1")
+    assert n.status == "done", n.status
+    assert n.score == 45.2
+    assert n.eval_status == "scored"
+    assert n.attempt == 1
+
+
+def test_timeout_marks_needs_retry():
+    tree = _make_tree("pending")
+    FakeAgent.raise_timeout = True
+    try:
+        _, _ = asyncio.run(_run(
+            tree,
+            parsed={"score": None, "eval_status": "failed_to_run", "insight": "", "result": ""},
+        ))
+    finally:
+        FakeAgent.raise_timeout = False
+    n = tree.get_node("1")
+    assert n.status == "needs_retry", n.status
+    assert n.score is None
+
+
+def test_max_turns_marks_needs_retry():
+    tree = _make_tree("pending")
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Agent stopped after 50 turns without a final answer."
+    FakeAgent.next_stop_reason = "max_turns"
+    _, _ = asyncio.run(_run(tree, parsed={"score": None, "eval_status": "failed_to_run", "insight": "", "result": ""}))
+    n = tree.get_node("1")
+    assert n.status == "needs_retry", n.status
+
+
+def test_needs_retry_consumes_cycle_through_lifecycle():
+    # Two nodes: dispatch one that ends needs_retry, then confirm the cycle counter
+    # advanced (so a perpetually-failing node still spends max_cycles budget).
+    tree = _make_tree("pending")
+    before = er._completed_cycles(tree)
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Agent stopped after 50 turns without a final answer."
+    FakeAgent.next_stop_reason = "max_turns"
+    asyncio.run(_run(tree, parsed={"score": None, "eval_status": "failed_to_run", "insight": "", "result": ""}))
+    after = er._completed_cycles(tree)
+    assert after == before + 1, (before, after)
+
+
+# ── Tests: resume path ───────────────────────────────────────────────────────
+
+def test_resume_branches_from_code_ref_and_bumps_turns():
+    tree = _make_tree("needs_retry", code_ref="coordinator/n1-x-abc123", attempt=1)
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Score: 51.0%"
+    FakeAgent.next_stop_reason = "finished"
+    _, rec = asyncio.run(_run(
+        tree,
+        parsed={"score": 51.0, "eval_status": "scored", "insight": "i", "result": "r"},
+        resume=True, extra_turns=7,
+    ))
+    # Worktree branched from the preserved branch, not trunk:
+    assert rec.create_kwargs["start_point"] == "coordinator/n1-x-abc123"
+    # Resume branch carries the attempt suffix:
+    assert rec.create_kwargs["branch_name"].endswith("-a2")
+    # Turn budget was raised by extra_turns (50 default + 7):
+    assert rec.executor_max_turns == 57, rec.executor_max_turns
+    # Prior context was injected into the prompt:
+    assert rec.injected_context is not None
+    assert "Resuming a prior attempt" in rec.injected_context
+    assert "coordinator/n1-x-abc123" in rec.injected_context
+    # Attempt counter advanced and the node is now done:
+    n = tree.get_node("1")
+    assert n.attempt == 2
+    assert n.status == "done"
+
+
+def test_resume_still_failing_increments_attempt():
+    tree = _make_tree("needs_retry", code_ref="br", attempt=2)
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Agent stopped after 50 turns without a final answer."
+    FakeAgent.next_stop_reason = "max_turns"
+    asyncio.run(_run(tree, parsed={"score": None, "eval_status": "failed_to_run", "insight": "", "result": ""},
+                     resume=True, extra_turns=5))
+    n = tree.get_node("1")
+    assert n.status == "needs_retry"
+    assert n.attempt == 3
+
+
+# ── Tests: dispatch guards ───────────────────────────────────────────────────
+
+def test_dispatch_guard_rejects_done_node():
+    tree = _make_tree("done")
+    out = asyncio.run(er._run_single_executor(
+        tree=tree, config=CoordinatorConfig(cwd="."), provider=object(), node_id="1",
+    ))
+    assert "status='done'" in out and "Only 'pending' or 'needs_retry'" in out
+
+
+def test_dispatch_guard_allows_needs_retry():
+    # Reaches the worktree stage (guard passed) — mock create to short-circuit.
+    tree = _make_tree("needs_retry", code_ref="br")
+    FakeAgent.raise_timeout = False
+    FakeAgent.next_report = "Score: 1.0%"
+    FakeAgent.next_stop_reason = "finished"
+    out, rec = asyncio.run(_run(tree, parsed={"score": 1.0, "eval_status": "scored", "insight": "", "result": ""}))
+    assert rec.create_kwargs is not None  # got past the guard
+    assert tree.get_node("1").status == "done"
+
+
+# ── Tests: ResumeExecutorTool guards ─────────────────────────────────────────
+
+def _resume_tool(tree):
+    return er.ResumeExecutorTool(
+        cwd=".", tree=tree, config=CoordinatorConfig(cwd="."), provider=object(),
+    )
+
+
+def test_resume_tool_rejects_non_needs_retry():
+    tree = _make_tree("done")
+    out = asyncio.run(_resume_tool(tree).execute(node_id="1"))
+    assert "only applies to 'needs_retry'" in out
+
+
+def test_resume_tool_rejects_missing_code_ref():
+    tree = _make_tree("needs_retry", code_ref=None)
+    out = asyncio.run(_resume_tool(tree).execute(node_id="1"))
+    assert "no preserved branch" in out
+
+
+def test_resume_tool_enforces_max_retries():
+    # max_retries=3 ⇒ allow while attempt<=3; attempt=4 is refused.
+    tree = _make_tree("needs_retry", code_ref="br", attempt=4)
+    out = asyncio.run(_resume_tool(tree).execute(node_id="1"))
+    assert "allowed retries" in out
+
+
+def test_resume_tool_allows_within_retry_budget():
+    tree = _make_tree("needs_retry", code_ref="br", attempt=3)
+    tool = _resume_tool(tree)
+    rec = _Recorder()
+    import contextlib
+    with contextlib.ExitStack() as stack:
+        for p in _patches(rec, {"score": 9.0, "eval_status": "scored", "insight": "", "result": ""}):
+            stack.enter_context(p)
+        out = asyncio.run(tool.execute(node_id="1", extra_turns=3))
+    assert "allowed retries" not in out
+    assert rec.create_kwargs is not None  # actually dispatched
+
+
+# ── Tests: artifacts + resume-context builder ────────────────────────────────
+
+def test_save_artifacts_includes_new_fields():
+    with tempfile.TemporaryDirectory() as ws:
+        cfg = CoordinatorConfig(cwd=".")
+        cfg.workspace_dir = ws
+        asyncio.run(er._save_experiment_artifacts(
+            config=cfg, node_id="1", hypothesis="h", raw_report="report body",
+            parsed={"score": None, "insight": "i", "result": "r"},
+            actual_branch="br", agent_turns=12,
+            status="needs_retry", eval_status="failed_to_run",
+            stop_reason="max_turns", attempt=2,
+        ))
+        metrics = json.loads((Path(ws) / "experiments" / "1" / "metrics.json").read_text())
+        assert metrics["status"] == "needs_retry"
+        assert metrics["eval_status"] == "failed_to_run"
+        assert metrics["stop_reason"] == "max_turns"
+        assert metrics["attempt"] == 2
+        report = (Path(ws) / "experiments" / "1" / "report.md").read_text()
+        assert "**Status**: needs_retry" in report
+        assert "**Attempt**: 2" in report
+
+
+def test_build_resume_context_reads_prior_artifacts():
+    with tempfile.TemporaryDirectory() as ws:
+        exp = Path(ws) / "experiments" / "1"
+        exp.mkdir(parents=True)
+        (exp / "report.md").write_text("PRIOR REPORT CONTENT")
+        (exp / "diff.patch").write_text("PRIOR DIFF CONTENT")
+        cfg = CoordinatorConfig(cwd=".")
+        cfg.workspace_dir = ws
+        node = Node(id="1", parent_id="ROOT", status="needs_retry",
+                    code_ref="br", eval_status="failed_to_run", stop_reason="max_turns",
+                    result="res", insight="ins")
+        ctx = er._build_resume_context(cfg, node, attempt=2)
+        assert "Resuming a prior attempt (attempt 2)" in ctx
+        assert "br" in ctx
+        assert "PRIOR REPORT CONTENT" in ctx
+        assert "PRIOR DIFF CONTENT" in ctx
+
+
+def test_build_resume_context_handles_missing_code_ref():
+    cfg = CoordinatorConfig(cwd=".")
+    cfg.workspace_dir = None
+    node = Node(id="1", parent_id="ROOT", status="needs_retry", code_ref=None)
+    ctx = er._build_resume_context(cfg, node, attempt=2)
+    assert "`None`" not in ctx
+    assert "starting from trunk" in ctx
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v) and not inspect.iscoroutinefunction(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"ok  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            import traceback
+            print(f"FAIL {t.__name__}: {e}")
+            traceback.print_exc()
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Problem

When an executor exhausts its turn budget, times out, errors, or produces no parseable score, the idea-tree node was still marked `status="done"` with `score=null`. Two consequences:

1. **Unscored runs masquerade as completed experiments** — the coordinator could build conclusions (best-node selection, convergence, final report) on experiments that never produced a result.
2. **No recovery path** — re-dispatch was gated to `pending`, so the only way to retry was to manually reset the node, which restarts the executor from turn 1 and discards the prior attempt's committed work.

## Changes

**Status correctness**
- `_classify_executor_outcome`: a node is only `done` with a real score (or an *intentionally* skipped eval). Turn-cap / timeout / error / unscored exits become a new **`needs_retry`** status.
- `needs_retry` is excluded from every "completed experiment" filter (best-node, convergence, reports) so it can't skew conclusions — but it **is** counted toward the cycle budget, so a perpetually-failing node still spends `max_cycles`.
- `Agent.stop_reason` (`"finished"` / `"max_turns"`) is exposed as a new attribute; `run()`'s return type is unchanged, so existing callers are untouched.

**Resume-with-context**
- New `ResumeExecutor(node_id, extra_turns=…)` continues a `needs_retry` node **from its preserved git branch** (`code_ref`) with the prior `report.md` / `diff.patch` injected as context and extra turns. Capped by a new `config.max_retries` (default 3).
- Exact message-history replay is intentionally out of scope — the committed code is already recovered via the branch, and re-grounding a fresh executor from the code + prior report avoids re-walking a stalled run.

**Bookkeeping & visibility**
- `eval_status` / `stop_reason` / `attempt` recorded on the node (back-compatible serialization) and in experiment artifacts.
- `needs_retry` surfaced in the terminal dashboard, web UI snapshot, event log, and coordinator prompt; `TreeUpdateNode` can set it manually.

## Behavior now

A turn-capped or unscored run shows up as `needs_retry`, stays out of the results until it actually has a score, and can be resumed (`ResumeExecutor`, continues from the preserved branch) or retried from trunk (`RunExecutor`).

## Tests

19 new tests (self-contained — run directly or via pytest):
- **Unit**: outcome classifier truth table, cycle-budget invariant, `Node` serialization round-trip + old-JSON back-compat.
- **Integration** (drive `_run_single_executor` end-to-end with Agent/git/parser mocked): timeout/max-turns/success classification, resume-from-branch + turn bump (50→57) + attempt counter, and all `ResumeExecutor` guards (status / missing `code_ref` / `max_retries`).