### PR TITLE
feat(config): add `auto` provider with setup-time backend detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,17 @@ pollutes the Coordinator's context. See [`docs/`](docs/index.md) for the full me
 ## ⚙️ Configuration
 
 LLM access is configured once with `arbor setup` (stored in `~/.arbor/config.yaml`) via a
-single `provider` field — `anthropic`, `openai` (incl. any OpenAI-compatible Responses
-endpoint), or `litellm` for DeepSeek / Gemini / Qwen / vLLM / Ollama / local gateways. Keys
-come from the environment or the config; per-project task and budget settings live in
+single `provider` field:
+
+| `provider` | Use it for |
+| --- | --- |
+| `auto` *(default)* | Let Arbor pick. It probes your endpoint's OpenAI **Responses** API and uses it when available (reasoning chain preserved), otherwise falls back to chat completions; Claude models use the native Anthropic API. The detected backend is frozen into the config. |
+| `openai-responses` | OpenAI / o-series models via the Responses API (encrypted reasoning chain preserved across turns). |
+| `openai-chat` | Any OpenAI-compatible chat-completions endpoint — DeepSeek / Qwen / GLM / vLLM / Ollama / local gateways. |
+| `anthropic` | Claude via the native Anthropic Messages API (signed thinking + prompt caching). |
+
+Most users just run `arbor setup`, keep `auto`, and fill in `model` + `base_url`. Keys come
+from the environment or the config; per-project task and budget settings live in
 `research_config.yaml`. See the
 [configuration guide](https://RUC-NLPIR.github.io/Arbor/docs/configuration/) and
 [`examples/research_config.example.yaml`](examples/research_config.example.yaml) for every

--- a/examples/research_config.example.yaml
+++ b/examples/research_config.example.yaml
@@ -10,10 +10,12 @@
 # ─────────────────────────────────────────────────────────────────────────────
 
 llm:
-  # The API type configured by `arbor setup` uses the same provider names:
+  # `provider` is the API type chosen by `arbor setup`:
+  #   auto             — probe the endpoint; use the Responses API when available,
+  #                      else chat completions (Claude → native Anthropic)
+  #   openai-responses — OpenAI / o-series via the Responses API (reasoning chain)
+  #   openai-chat      — any OpenAI-compatible chat-completions endpoint
   #   anthropic        — native Anthropic Messages API (thinking + caching)
-  #   openai           — native OpenAI Responses API by default
-  #   litellm          — unified transport for every chat model / proxy
 
   provider: anthropic
   model: claude-sonnet-4-20250514
@@ -45,29 +47,36 @@ ui:
 # ─────────────────────────────────────────────────────────────────────────────
 #
 # OpenAI gpt-5 with the reasoning chain preserved (Responses API):
-#   provider: openai
+#   provider: openai-responses
 #   model: gpt-5.5
 #   reasoning_effort: high             # api_key from OPENAI_API_KEY env
 #
-# DeepSeek-R1 (litellm; reasoning_content carried back automatically):
-#   provider: litellm
-#   model: deepseek/deepseek-reasoner  # api_key from DEEPSEEK_API_KEY env
+# DeepSeek (chat completions; reasoning_content shown live):
+#   provider: openai-chat
+#   model: deepseek-reasoner           # or deepseek-chat
+#   base_url: https://api.deepseek.com
+#   api_key: sk-...
+#
+# Qwen via Alibaba DashScope — let `auto` probe Responses vs chat:
+#   provider: auto
+#   model: qwen3.7-max
+#   base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+#   api_key: sk-...
 #
 # Self-hosted vLLM / Ollama (chat-only endpoint):
-#   provider: openai
+#   provider: openai-chat
 #   model: Qwen/Qwen2.5-72B-Instruct
 #   base_url: http://localhost:8000/v1
 #   api_key: dummy
-#   openai_api: chat
 #
-# A litellm proxy serving gpt-5.5 (chain via Responses):
-#   provider: openai
+# A local proxy serving gpt-5.5 via the Responses API:
+#   provider: openai-responses
 #   model: gpt-5.5
-#   base_url: http://your-litellm-proxy/v1
+#   base_url: http://your-proxy/v1
 #   api_key: sk-...
 #
-# A Copilot-style proxy serving claude / gemini (chain via litellm opaque token):
-#   provider: litellm                  # or auto
+# A Copilot-style proxy serving claude / gemini — `auto` picks the backend:
+#   provider: auto
 #   model: gemini-3.1-pro-preview
 #   base_url: http://localhost:4141/v1
 #   api_key: dummy

--- a/src/cli/_autodetect.py
+++ b/src/cli/_autodetect.py
@@ -1,0 +1,101 @@
+"""Setup-time backend auto-detection for ``provider: auto``.
+
+When the user picks ``auto`` we resolve it to a *concrete* backend **once**, at
+``arbor setup`` / ``arbor config init`` time, and freeze the result in the config
+file. The runtime stays pure and fast (``resolve_backend`` never touches the
+network); the only network probe happens here, during setup.
+
+Resolution rules:
+
+* ``claude*`` → ``anthropic`` (native Messages API: signed thinking blocks +
+  prompt caching), against the official endpoint or a custom ``base_url``.
+* Anything else → **probe** ``{base_url}/responses``. If the endpoint serves the
+  OpenAI Responses API we pick ``openai-responses`` so the reasoning chain is
+  preserved across ReAct turns; otherwise we fall back to ``openai-chat`` (chat
+  completions), which every OpenAI-compatible endpoint supports.
+
+The probe is best-effort and never raises — an inconclusive result (network
+error, bad key, …) falls back to ``openai-chat``, which the user can always
+override by setting ``provider`` explicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+# How long to wait for the one-shot Responses probe before giving up and
+# falling back to chat completions. Setup is interactive, so keep it snappy.
+_PROBE_TIMEOUT = 10.0
+
+
+def probe_responses_api(
+    *,
+    model: str,
+    base_url: str | None,
+    api_key: str | None,
+    timeout: float = _PROBE_TIMEOUT,
+) -> bool:
+    """Best-effort: ``True`` iff ``{base_url}/responses`` actually answers this
+    model with a usable response.
+
+    Never raises. Only a clean success counts as "supported" — this is
+    deliberately conservative. A false positive (picking the Responses API when
+    it won't work) breaks every run, which is exactly the failure we're trying
+    to prevent; a false negative merely costs the reasoning-chain upgrade and
+    falls back to chat completions, which still works. Note that a route can
+    *exist* yet reject the model (e.g. a proxy that answers ``/responses`` with
+    400 "this model does not support the responses endpoint"), so "the route is
+    there" is not enough — we require an actual 2xx.
+    """
+    try:
+        from openai import OpenAI
+    except Exception:  # pragma: no cover - openai always installed in practice
+        return False
+
+    try:
+        client = OpenAI(
+            api_key=api_key or "dummy",
+            base_url=base_url or None,
+            max_retries=0,
+            timeout=timeout,
+        )
+        # Minimal request: no reasoning, tiny output. We only care whether the
+        # /responses route returns a usable response for this model.
+        resp = client.responses.create(model=model, input="ping", max_output_tokens=16)
+        # A genuine Responses API returns an object with an id; anything else
+        # (a chat shim echoing JSON, an empty body, …) is not the real thing.
+        return getattr(resp, "id", None) is not None
+    except Exception as e:
+        # 404 (no route), 400 (route exists but model unsupported / bad request),
+        # auth, connection, timeout — all inconclusive or negative. Fall back to
+        # the universal chat path.
+        log.debug("responses probe failed for %s @ %s: %s", model, base_url, e)
+        return False
+
+
+def resolve_auto_provider(
+    *,
+    model: str,
+    base_url: str | None,
+    api_key: str | None,
+    timeout: float = _PROBE_TIMEOUT,
+) -> tuple[str, str]:
+    """Resolve ``provider: auto`` to a concrete backend at setup time.
+
+    Returns ``(provider, reason)`` where ``provider`` is one of ``anthropic`` |
+    ``openai-responses`` | ``openai-chat`` (the user-facing menu values minus
+    ``auto``) and ``reason`` is a short human-readable note for the setup output.
+    """
+    bare = (model or "").rsplit("/", 1)[-1].lower()
+
+    if bare.startswith(("claude", "anthropic")):
+        return "anthropic", "Claude model → native Anthropic Messages API"
+
+    if probe_responses_api(model=model, base_url=base_url, api_key=api_key, timeout=timeout):
+        return (
+            "openai-responses",
+            "endpoint serves the Responses API → openai-responses (reasoning chain preserved)",
+        )
+    return "openai-chat", "no Responses API on this endpoint → openai-chat (chat completions)"

--- a/src/cli/_constants.py
+++ b/src/cli/_constants.py
@@ -8,7 +8,16 @@ quietly disagree.
 
 from __future__ import annotations
 
-VALID_PROVIDERS = {"anthropic", "openai", "litellm"}
+# User-facing provider menu (setup wizard + `config init --provider`), in
+# display order. Each is a single-axis value that maps 1:1 onto a backend, so
+# the config file reads the same as the menu. `auto` resolves to one of the
+# concrete three at setup time.
+PROVIDER_CHOICES = ("auto", "openai-responses", "openai-chat", "anthropic")
+
+# Concrete providers Arbor can store + serve after `auto` is resolved. `litellm`
+# stays a valid backend for back-compat / advanced hand-edited configs, but is
+# no longer advertised in the menu.
+_BACKEND_PROVIDERS = {"anthropic", "openai-responses", "openai-chat", "litellm"}
 VALID_OPENAI_APIS = {"chat", "responses"}
 
 # Intake-agent LLM call budget — seeded into the agent config by ``run`` and
@@ -33,33 +42,40 @@ DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-20250514"
 DEFAULT_WEBUI_PORT = 8765
 WEBUI_PORT_SCAN = 10
 
-_OPENAI_FAMILY = ("openai", "litellm")
 
+def canonical_provider(provider: str | None, openai_api: str | None = None) -> str:
+    """Collapse any provider alias onto a single canonical, single-axis value.
 
-def normalize_provider(provider: str | None, openai_api: str | None = None) -> str:
-    """Return the canonical provider name stored in config files.
-
-    User-facing setup uses one axis only: anthropic | openai | litellm.
-    ``openai`` defaults to the Responses API; advanced configs may still set
-    ``openai_api: chat`` in YAML for chat-only endpoints.
+    Returns one of ``auto`` | ``anthropic`` | ``openai-responses`` |
+    ``openai-chat`` | ``litellm``. The legacy two-axis form (``openai`` plus
+    ``openai_api: chat|responses``) folds into the matching ``openai-*`` value,
+    so newly written configs only ever carry the single ``provider`` field.
     """
     p = (provider or "anthropic").strip().lower()
-    if p == "claude":
+    api = (openai_api or "").strip().lower()
+    if p == "auto":
+        return "auto"
+    if p in ("claude", "anthropic"):
         return "anthropic"
-    if p in ("openai", "openai-responses", "openai-chat", "responses", "chat", "openai_response", "openai_compat"):
-        return "openai"
-    return p
+    if p == "litellm":
+        return "litellm"
+    if p in ("openai-chat", "chat", "openai_compat", "openai_chat"):
+        return "openai-chat"
+    if p in ("openai-responses", "responses", "openai_responses", "openai_response"):
+        return "openai-responses"
+    if p == "openai":  # legacy bare provider: respect the openai_api axis
+        return "openai-chat" if api == "chat" else "openai-responses"
+    return p  # unknown → passthrough; resolve_backend decides or errors later
 
 
 def default_model_for_provider(provider: str | None) -> str | None:
     """Default model for ``provider``, or ``None`` to defer to the provider.
 
-    Claude/Anthropic return ``None`` because the provider supplies its own
-    default; only the OpenAI family and litellm need an explicit model here.
-    Callers that must persist a concrete string (e.g. writing a config file)
-    substitute :data:`DEFAULT_CLAUDE_MODEL` when this returns ``None``.
+    ``anthropic``/``auto`` return ``None`` because Claude supplies its own
+    default; the OpenAI family and litellm need an explicit model here. Callers
+    that must persist a concrete string substitute :data:`DEFAULT_CLAUDE_MODEL`.
     """
-    provider = normalize_provider(provider)
-    if provider in _OPENAI_FAMILY:
+    canon = canonical_provider(provider)
+    if canon.startswith("openai") or canon == "litellm":
         return DEFAULT_OPENAI_MODEL
     return None

--- a/src/cli/commands/config_cmd.py
+++ b/src/cli/commands/config_cmd.py
@@ -11,9 +11,10 @@ import yaml
 from ..._app import GLOBAL_CONFIG_DIR, GLOBAL_CONFIG_FILE, LEGACY_GLOBAL_CONFIG_FILE
 from .._constants import (
     DEFAULT_CLAUDE_MODEL,
-    VALID_PROVIDERS,
+    PROVIDER_CHOICES,
+    _BACKEND_PROVIDERS,
+    canonical_provider,
     default_model_for_provider,
-    normalize_provider,
 )
 
 
@@ -46,8 +47,9 @@ def show_command(
 @config_app.command("init")
 def init_command(
     provider: str = typer.Option(
-        "anthropic", "--provider",
-        help="API type: anthropic / openai / litellm. OpenAI defaults to Responses API.",
+        "auto", "--provider",
+        help="API type: auto / openai-responses / openai-chat / anthropic. "
+             "auto probes the endpoint and picks the best backend.",
     ),
     model: str | None = typer.Option(None, "--model",
                                      help="Model name. Defaults to a provider-appropriate model."),
@@ -61,22 +63,27 @@ def init_command(
 
     Examples:
 
-            # local proxy serving a gpt-5.x / o-series model (uses Responses API)
-            arbor config init --provider openai --model gpt-5.5 \
+            # auto — let Arbor probe the endpoint and pick the best backend
+            # (recommended for DeepSeek / Qwen / GLM and other OpenAI-compatible APIs)
+            arbor config init --provider auto --model deepseek-reasoner \
+                --base-url https://api.deepseek.com --api-key sk-...
+
+            # OpenAI / o-series via the Responses API (reasoning chain preserved)
+            arbor config init --provider openai-responses --model gpt-5.5 \
                 --base-url http://localhost:4141 --api-key dummy
 
-            # local proxy serving an open-source model via litellm
-            arbor config init --provider litellm --model qwen-72b \
-                --base-url http://localhost:4141 --api-key dummy
+            # any OpenAI-compatible chat-completions endpoint
+            arbor config init --provider openai-chat --model qwen3.7-max \
+                --base-url https://dashscope.aliyuncs.com/compatible-mode/v1 --api-key sk-...
 
               # Claude via Anthropic with env-var ANTHROPIC_API_KEY
               arbor config init --provider anthropic --model claude-sonnet-4-20250514
     """
-    provider = normalize_provider(provider)
-
-    if provider not in VALID_PROVIDERS:
+    canon = canonical_provider(provider)
+    if canon != "auto" and canon not in _BACKEND_PROVIDERS:
         typer.secho(
-            f"error: --provider must be anthropic, openai, or litellm (got {provider!r})",
+            "error: --provider must be one of "
+            f"{' / '.join(PROVIDER_CHOICES)} (got {provider!r})",
             fg=typer.colors.RED,
             err=True,
         )
@@ -89,8 +96,8 @@ def init_command(
 
     GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
-    resolved_model = model or default_model_for_provider(provider) or DEFAULT_CLAUDE_MODEL
-    llm: dict[str, str] = {"provider": provider, "model": resolved_model}
+    resolved_model = model or default_model_for_provider(canon) or DEFAULT_CLAUDE_MODEL
+    llm: dict[str, str] = {"provider": canon, "model": resolved_model}
     if base_url:
         llm["base_url"] = base_url
     if api_key:
@@ -106,21 +113,38 @@ def write_user_llm_config(llm: dict[str, Any]) -> None:
     both produce the same file shape. Callers own the "exists + not --force" guard
     and the ``GLOBAL_CONFIG_DIR.mkdir`` is repeated here so the wizard can call
     this directly without depending on init's prologue.
+
+    When ``provider`` is ``auto`` it is resolved to a concrete backend here (a
+    one-shot Responses-API probe for non-Claude endpoints) and the *resolved*
+    value is what gets written, so the runtime never has to probe.
     """
     GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     llm = dict(llm)
-    original_provider = str(llm.get("provider") or "anthropic")
     original_openai_api = str(llm.pop("openai_api", "") or "") or None
-    llm["provider"] = normalize_provider(
-        original_provider,
-        original_openai_api,
-    )
-    if original_provider.lower() in {"openai-chat", "chat", "openai_compat"}:
-        llm["openai_api"] = "chat"
-    elif original_openai_api and original_openai_api.lower() == "chat":
-        llm["openai_api"] = "chat"
     if llm.get("base_url"):
         llm["base_url"] = _normalize_base_url(str(llm["base_url"]))
+
+    # provider=auto: resolve to a concrete backend now (once) and freeze it, so
+    # the runtime path stays pure (no per-run probing). Non-Claude endpoints are
+    # probed for the Responses API — `openai-responses` when present (reasoning
+    # chain preserved across turns), else `openai-chat` (chat completions).
+    if (str(llm.get("provider") or "")).strip().lower() == "auto":
+        from .._autodetect import resolve_auto_provider
+
+        typer.secho("auto: detecting the best backend for this endpoint…", fg=typer.colors.CYAN)
+        resolved, reason = resolve_auto_provider(
+            model=str(llm.get("model") or ""),
+            base_url=llm.get("base_url"),
+            api_key=llm.get("api_key"),
+        )
+        typer.secho(f"auto: {reason} (provider={resolved})", fg=typer.colors.CYAN)
+        llm["provider"] = resolved
+
+    # Store a single canonical, single-axis provider so the file reads the same
+    # as the menu (e.g. `openai-chat`, not `openai` + `openai_api: chat`). Legacy
+    # two-axis input still folds in via `original_openai_api`.
+    llm["provider"] = canonical_provider(llm.get("provider"), original_openai_api)
+
     payload = {"llm": llm}
     GLOBAL_CONFIG_FILE.write_text(
         yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),

--- a/src/cli/commands/setup_cmd.py
+++ b/src/cli/commands/setup_cmd.py
@@ -15,7 +15,7 @@ import typer
 from ..._app import GLOBAL_CONFIG_FILE
 from .._constants import (
     DEFAULT_CLAUDE_MODEL,
-    VALID_PROVIDERS,
+    PROVIDER_CHOICES,
     default_model_for_provider,
 )
 from .config_cmd import write_user_llm_config
@@ -42,10 +42,18 @@ def run_setup_wizard(*, force: bool = False) -> bool:
                    f"{GLOBAL_CONFIG_FILE}.[/]\n")
 
     # 1. API type / provider
+    _console.print(
+        "[dim]API type:\n"
+        "  [bold]auto[/bold]             let Arbor detect it — probes the endpoint's Responses\n"
+        "                   API and uses it when available, else chat completions\n"
+        "  [bold]openai-responses[/bold] OpenAI / o-series via the Responses API (reasoning chain)\n"
+        "  [bold]openai-chat[/bold]      any OpenAI-compatible endpoint (DeepSeek / Qwen / GLM / …)\n"
+        "  [bold]anthropic[/bold]        Claude via the native Anthropic API[/]"
+    )
     provider = _prompt_choice(
         "API type",
-        choices=sorted(VALID_PROVIDERS),
-        default="anthropic",
+        choices=list(PROVIDER_CHOICES),
+        default="auto",
     )
 
     # 2. base_url (local proxy / vLLM / official API)


### PR DESCRIPTION
Replace the setup/config-init provider menu with a clearer, single-axis set: `auto` / `openai-responses` / `openai-chat` / `anthropic` (drop the ambiguous bare `openai` and the library-named `litellm` from the menu; both still work at runtime for back-compat).

`auto` (now the default) resolves once at `arbor setup` / `config init` time and freezes a concrete backend into the config, so the runtime path stays pure:
- Claude models -> native Anthropic.
- Otherwise probe `{base_url}/responses`; a clean 2xx -> `openai-responses` (reasoning chain preserved across turns), anything else -> `openai-chat` (chat completions, universally supported). The probe is conservative (200-only) because a false positive breaks every run while a false negative only costs the reasoning upgrade.

Configs are now stored single-axis (e.g. `provider: openai-chat`) so the file reads the same as the menu; the legacy two-axis form (`openai` + `openai_api`) still folds in via `canonical_provider`.

Update the README configuration section and the example config accordingly.