### PR TITLE
docs(zh): align zh-CN config section with the new provider menu

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -199,7 +199,16 @@ ROOT（基线：20%）
 
 ## ⚙️ 配置
 
-通过 `arbor setup` 一次性配置 LLM 访问（存储在 `~/.arbor/config.yaml`），只需填写一个 `provider` 字段——`anthropic` 用于官方 Anthropic Claude API，`openai` 用于官方 OpenAI API，`litellm` 用于其他所有兼容 provider、代理或本地网关。即使第三方服务提供 OpenAI 或 Claude 格式的接口，也应通过 `litellm` 配置；例如 DeepSeek 应使用 `litellm`。API 密钥从环境变量或配置文件中读取；针对具体项目的任务和预算配置则放在 `research_config.yaml` 中。详情请参阅[配置指南](https://ruc-nlpir.github.io/Arbor/docs/configuration/)和 [`examples/research_config.example.yaml`](https://claude.ai/chat/examples/research_config.example.yaml)。
+通过 `arbor setup` 一次性配置 LLM 访问（存储在 `~/.arbor/config.yaml`），只需填写一个 `provider` 字段：
+
+| `provider` | 适用场景 |
+| --- | --- |
+| `auto`（默认） | 交给 Arbor 自动判断：探测端点的 OpenAI **Responses** API，支持就用（保留思维链），否则回退到 chat completions；Claude 模型走原生 Anthropic API。探测结果会被冻结写入配置。 |
+| `openai-responses` | OpenAI / o 系列模型，走 Responses API（跨轮保留加密思维链）。 |
+| `openai-chat` | 任何 OpenAI 兼容的 chat-completions 端点——DeepSeek / Qwen / GLM / vLLM / Ollama / 本地网关。 |
+| `anthropic` | Claude，走原生 Anthropic Messages API（签名思维块 + 提示缓存）。 |
+
+大多数用户只需运行 `arbor setup`、保持 `auto`、填好 `model` 与 `base_url` 即可。API 密钥从环境变量或配置文件中读取；针对具体项目的任务和预算配置则放在 `research_config.yaml` 中。详情请参阅[配置指南](https://ruc-nlpir.github.io/Arbor/docs/configuration/)和 [`examples/research_config.example.yaml`](examples/research_config.example.yaml)。
 
 ------
 


### PR DESCRIPTION
The zh-CN README still told users to configure DeepSeek (and all third-party endpoints) via `provider: litellm`, which contradicts the new menu (`auto` / `openai-responses` / `openai-chat` / `anthropic`). Mirror the English table and fix a broken example link that had been rewritten to a chat URL.

<!--
  Thanks for contributing to Arbor! / 感谢为 Arbor 贡献代码！
  Keep PRs small and focused. Fill in the sections below.
  请保持 PR 小而聚焦，并填写下面的内容。
-->

## Summary / 概述

<!-- What does this PR do, and why? / 这个 PR 做了什么、为什么这么做？ -->

## Linked issue / 关联 issue

<!-- e.g. Closes #123 — required for bug fixes & features / 修复缺陷或新功能请关联 issue -->
Closes #

## Type of change / 改动类型

- [ ] 🐞 Bug fix / 缺陷修复 (`fix`)
- [x] ✨ Feature / 新功能 (`feat`)
- [ ] 📝 Docs / 文档 (`docs`)
- [ ] ♻️ Refactor / 重构 (`refactor`)
- [ ] ✅ Tests / 测试 (`test`)
- [ ] 🔧 Chore / build / CI (`chore`)

## How was this tested? / 如何验证？

<!-- Commands you ran and what you observed. / 你运行的命令以及观察到的结果。 -->

```text

```

## Checklist / 检查清单

- [ ] PR title follows Conventional Commits (e.g. `fix(config): ...`). / PR 标题遵循 Conventional Commits 规范。
- [ ] The change is focused and reasonably small. / 改动聚焦且体量合理。
- [ ] I ran the relevant tests locally (`python tests/test_*.py`) and they pass. / 我已在本地运行相关测试并通过。
- [ ] Docs / examples updated if behavior or config changed. / 若行为或配置有变更，已同步更新文档/示例（含 `README.zh-CN.md`）。
- [ ] No secrets, API keys, or tokens are included in the diff. / diff 中不包含任何密钥、API key 或 token。
