### PR TITLE
docs(readme): introduce the runnable algotune_knn example task

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,27 @@ executor:
 A copy-pasteable example with every option lives in
 [`examples/research_config.example.yaml`](examples/research_config.example.yaml).
 
+### Try the runnable example task
+
+If you just want to watch Arbor work end-to-end — **no API budget, no GPU** —
+[`examples/algotune_knn/`](examples/algotune_knn) is a tiny, self-contained
+benchmark modeled on [AlgoTune](https://algotune.io/). The task is to make a
+brute-force k-nearest-neighbours solver **faster** while producing the **same**
+output; the metric is the speedup over a reference implementation. It is pure
+NumPy, CPU-only, sub-second, and deterministic, with several genuine
+optimizations for the Idea Tree to discover.
+
+```bash
+cp -r examples/algotune_knn /tmp/algotune_knn   # run outside the Arbor checkout
+cd /tmp/algotune_knn
+git init -q && git add -A && git commit -qm baseline
+arbor
+```
+
+In one 6-cycle run this drove the dev speedup from **1.01x → 7.77x** (held-out
+test **1.00x → 7.22x**). See [`examples/algotune_knn/README.md`](examples/algotune_knn/README.md)
+for the research contract and tuning knobs.
+
 ---
 
 ## 🧠 How It Works

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -155,6 +155,24 @@ executor:
 
 包含所有选项的完整示例配置文件位于 [`examples/research_config.example.yaml`](https://claude.ai/chat/examples/research_config.example.yaml)。
 
+### 试用可运行的示例任务
+
+如果你只想完整地看一遍 Arbor 是怎么工作的——**不耗 API 预算、不需要 GPU**——
+[`examples/algotune_knn/`](examples/algotune_knn) 是一个仿照 [AlgoTune](https://algotune.io/)
+的迷你基准。任务是让一个暴力 k 近邻求解器在**输出完全相同**的前提下**跑得更快**，
+指标是相对参考实现的加速比。它纯 NumPy、仅用 CPU、亚秒级、且完全确定性，并留有多个
+真实可达的优化点供想法树去发现。
+
+```bash
+cp -r examples/algotune_knn /tmp/algotune_knn   # 在 Arbor 仓库之外运行
+cd /tmp/algotune_knn
+git init -q && git add -A && git commit -qm baseline
+arbor
+```
+
+在一次 6 轮的运行中，它把开发集加速比从 **1.01x 提升到 7.77x**（留出测试集 **1.00x → 7.22x**）。
+研究契约与可调参数详见 [`examples/algotune_knn/README.md`](examples/algotune_knn/README.md)。
+
 ------
 
 ## 🧠 工作原理


### PR DESCRIPTION
## What

Adds a short **"Try the runnable example task"** subsection to both `README.md`
and `README.zh-CN.md`, under *Prepare a benchmark*.

Follow-up to #10, which added `examples/algotune_knn/` but did not surface it
from the top-level README.

## Why

New users get a no-API-key, no-GPU, sub-second way to watch Arbor's full loop
end-to-end, with the copy-out run flow that keeps their Arbor checkout's git
clean. Points to `examples/algotune_knn/README.md` for the research contract and
tuning knobs, and cites the real 1.01x → 7.77x (held-out 7.22x) run.

## Notes

- Docs-only; English + Simplified Chinese kept in sync.