### PR TITLE
docs(guides): point quickstart and benchmark prep at the algotune_knn example

### DIFF
--- a/docs/preparing-a-benchmark.md
+++ b/docs/preparing-a-benchmark.md
@@ -6,6 +6,12 @@ what the metric means, what's off-limits, how ambitious to be — you settle in 
 **intake chat** when you launch `arbor`. No hand-written YAML, no eval contract to author,
 and **no README required**.
 
+!!! tip "Prefer to learn by example?"
+    [`examples/algotune_knn`](https://github.com/RUC-NLPIR/Arbor/tree/main/examples/algotune_knn)
+    is a tiny, runnable benchmark that already follows everything below — an editable
+    `solution.py`, a protected `eval.sh` that prints `score:`, and disjoint dev/test
+    seeds. It's the fastest way to see the shape of a benchmark before wiring up your own.
+
 ## 1. A scorable baseline repo
 
 Put your code and data in one directory — typically the repo you already have:

--- a/docs/preparing-a-benchmark.zh.md
+++ b/docs/preparing-a-benchmark.zh.md
@@ -5,6 +5,12 @@
 启动 `arbor` 时的一段简短**接入对话（intake chat）**里确定。无需手写 YAML，无需撰写评测契约，
 **也不需要 README**。
 
+!!! tip "想边看例子边学？"
+    [`examples/algotune_knn`](https://github.com/RUC-NLPIR/Arbor/tree/main/examples/algotune_knn)
+    是一个小而可运行的基准，已经遵循了下面的全部要点——一个可编辑的 `solution.py`、
+    一个打印 `score:` 的受保护 `eval.sh`，以及互不重叠的 dev/test 种子。在动手搭建
+    自己的基准之前，这是最快理解“基准长什么样”的方式。
+
 ## 1. 一个可评分的基线仓库
 
 把你的代码和数据放在一个目录里——通常就是你已有的仓库：

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -52,6 +52,19 @@ reads your code and README, confirms the metric and baseline, helps you shape a 
 then launches the study once you both agree. From there you stay in the same terminal —
 watching progress and steering the run with slash commands.
 
+!!! tip "No project yet? Try the bundled example"
+    For a no-API-budget, no-GPU, sub-second run you can watch end-to-end, use the
+    [`examples/algotune_knn`](https://github.com/RUC-NLPIR/Arbor/tree/main/examples/algotune_knn)
+    task — make a brute-force k-NN solver faster while matching the reference output.
+    Run it **outside** your Arbor checkout so experiment worktrees don't touch that repo:
+
+    ```bash
+    cp -r examples/algotune_knn /tmp/algotune_knn
+    cd /tmp/algotune_knn
+    git init -q && git add -A && git commit -qm baseline
+    arbor
+    ```
+
 !!! tip "Seed the goal up front"
     You can pass your objective as the first argument and still go through intake:
 

--- a/docs/quickstart.zh.md
+++ b/docs/quickstart.zh.md
@@ -51,6 +51,19 @@ arbor
 README，确认指标与基线，帮你完善出一个计划，待双方达成一致后启动研究。之后你便留在同一个终端中
 ——观察进度，并用斜杠命令引导运行。
 
+!!! tip "还没有项目？试试自带的示例"
+    想要一次**不耗 API、不需 GPU、亚秒级**且能完整旁观的运行，可以用
+    [`examples/algotune_knn`](https://github.com/RUC-NLPIR/Arbor/tree/main/examples/algotune_knn)
+    任务——在匹配参考输出的前提下，让一个暴力 k-NN 求解器跑得更快。请在你的 Arbor
+    仓库**之外**运行它，以免实验 worktree 影响该仓库：
+
+    ```bash
+    cp -r examples/algotune_knn /tmp/algotune_knn
+    cd /tmp/algotune_knn
+    git init -q && git add -A && git commit -qm baseline
+    arbor
+    ```
+
 !!! tip "一开始就给出目标"
     你可以把目标作为第一个参数传入，并仍然走接入流程：
 


### PR DESCRIPTION
## What

Surfaces the bundled `examples/algotune_knn` task from the two docs pages where
a new user is most likely to look for a first run:

- **Quickstart** → a tip under *Start a session* with the copy-out run snippet.
- **Preparing a Benchmark** → a "learn by example" callout near the top, framing
  the example as a ready-made instance of the contract the page describes.

English and Simplified Chinese kept in sync (4 files). Follow-up to #10 (example)
and #11 (top-level README).

## Why

The example is the fastest no-API-key, no-GPU way to see Arbor's full loop. The
docs now route users to it, and the snippet runs it **outside** the Arbor
checkout so experiment worktrees never touch the user's repo.

## Notes

- Docs-only.