### PR TITLE
fix(intake): raise intake LLM timeout for slow reasoning models

### DIFF
--- a/src/cli/_constants.py
+++ b/src/cli/_constants.py
@@ -22,11 +22,14 @@ VALID_OPENAI_APIS = {"chat", "responses"}
 
 # Intake-agent LLM call budget — seeded into the agent config by ``run`` and
 # applied directly by the REPL.
-INTAKE_LLM_TIMEOUT = 20.0
+# Some reasoning models (e.g. Claude Opus 4.x) take longer than 20s on the first
+# intake call, which made intake time out and report the model as unavailable.
+# Use a 120s budget with one extra retry so the intake call can complete.
+INTAKE_LLM_TIMEOUT = 120.0
 INTAKE_LLM_PROVIDER_RETRIES = 0
-INTAKE_LLM_RETRY_ATTEMPTS = 2
+INTAKE_LLM_RETRY_ATTEMPTS = 3
 INTAKE_LLM_RETRY_BASE_DELAY = 1.0
-INTAKE_LLM_RETRY_MAX_DELAY = 2.0
+INTAKE_LLM_RETRY_MAX_DELAY = 4.0
 
 # Intake is a planning conversation (read the eval, propose a contract), not a
 # deep-reasoning task — so it overrides the user's reasoning_effort (often


### PR DESCRIPTION
## Summary / 概述
With `provider: anthropic` and `model: claude-opus-4-8` (or `-opus-4-7`), intake fails before the agent starts — the planning model never answers and Arbor stays stuck in intake:

```
LLM call failed (turn 1, attempt 1/2): Request timed out or interrupted.
LLM call failed (turn 1, attempt 2/2): Request timed out or interrupted.
LLM error after 2 attempts: Request timed out or interrupted.
```

Intake uses a fixed 20s per-call timeout with 2 attempts. Opus 4.x takes longer than 20s on the first intake call, so every attempt times out before the model responds.

This PR raises the intake budget:
- `INTAKE_LLM_TIMEOUT` 20.0 → **120.0**
- `INTAKE_LLM_RETRY_ATTEMPTS` 2 → **3**
- `INTAKE_LLM_RETRY_MAX_DELAY` 2.0 → **4.0**

Faster models are unaffected — they finish well within the 120s ceiling.

## Type of change / 改动类型
- [x] 🐞 Bug fix / 缺陷修复 (`fix`)

## How was this tested? / 如何验证？
`arbor run` with `provider: anthropic` / `model: claude-opus-4-8` now completes intake and launches the research loop, where the old 20s budget produced the timeout trace above. Faster models (e.g. `claude-sonnet-4-*`) are unchanged.

## Checklist / 检查清单
- [x] PR title follows Conventional Commits
- [x] The change is focused and reasonably small
- [x] No secrets, API keys, or tokens are included in the diff
