### PR TITLE
feat(llm): experimental ChatGPT subscription OAuth backend + setup reasoning-effort

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,6 +155,24 @@ three:
     Prefer an environment variable (`${ANTHROPIC_API_KEY}`) over pasting a secret into a
     file. `arbor setup` stores your global key under `~/.arbor/` with the rest of the config.
 
+!!! warning "Experimental: ChatGPT subscription login (`openai-oauth`)"
+    ChatGPT Plus/Pro/Team subscribers can drive Arbor with their subscription instead of a
+    pay-per-token key. Run `arbor login openai` to sign in through the browser; the token is
+    stored in `~/.arbor/oauth/openai.json` and refreshed automatically. This writes:
+
+    ```yaml
+    llm:
+      provider: openai-oauth
+      model: gpt-5
+    ```
+
+    Manage the session with `arbor login status` / `arbor login logout`. Requests go to the
+    ChatGPT backend (`chatgpt.com/backend-api/codex`), **not** `api.openai.com`.
+
+    Using a subscription token with third-party tooling may violate OpenAI's terms and can
+    get your account rate-limited or banned. This path is opt-in and unsupported — prefer a
+    standard `OPENAI_API_KEY` for anything you care about.
+
 ### 3. Per-project: a config file
 
 When a project needs its own durable settings, drop a YAML file in it. Arbor auto-detects

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -143,6 +143,23 @@ arbor config init --provider litellm --model qwen-72b \
     优先用环境变量（`${ANTHROPIC_API_KEY}`），而非把密钥粘进文件。`arbor setup` 会把你的全局 key
     连同其余配置一起存在 `~/.arbor/` 下。
 
+!!! warning "实验性：用 ChatGPT 订阅登录（`openai-oauth`）"
+    ChatGPT Plus/Pro/Team 订阅用户可以用月费订阅来跑 Arbor，而不必用按量计费的 API key。
+    运行 `arbor login openai` 通过浏览器登录；token 存在 `~/.arbor/oauth/openai.json` 并自动刷新。
+    它会写入：
+
+    ```yaml
+    llm:
+      provider: openai-oauth
+      model: gpt-5
+    ```
+
+    用 `arbor login status` / `arbor login logout` 管理会话。请求发往 ChatGPT 后端
+    （`chatgpt.com/backend-api/codex`），**不是** `api.openai.com`。
+
+    用订阅 token 接第三方工具可能违反 OpenAI 条款，并有被限流或封号的风险。此路径为可选、
+    不受支持——正式用途请优先使用标准的 `OPENAI_API_KEY`。
+
 ### 3. 按项目：一个配置文件 { #3-per-project-a-config-file }
 
 当一个项目需要它自己的持久设置时，往里放一个 YAML 文件。Arbor 会自动检测目标目录里的

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "anthropic>=0.52.0",
     "openai>=1.30.0",
     "litellm>=1.55.0",
+    "httpx>=0.27.0",
     "tiktoken>=0.7.0",
     "typer>=0.12.0",
     "rich>=13.0",

--- a/src/cli/_constants.py
+++ b/src/cli/_constants.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 # display order. Each is a single-axis value that maps 1:1 onto a backend, so
 # the config file reads the same as the menu. `auto` resolves to one of the
 # concrete three at setup time.
-PROVIDER_CHOICES = ("auto", "openai-responses", "openai-chat", "anthropic")
+PROVIDER_CHOICES = ("auto", "openai-responses", "openai-chat", "openai-oauth", "anthropic")
 
 # Concrete providers Arbor can store + serve after `auto` is resolved. `litellm`
 # stays a valid backend for back-compat / advanced hand-edited configs, but is
 # no longer advertised in the menu.
-_BACKEND_PROVIDERS = {"anthropic", "openai-responses", "openai-chat", "litellm"}
+_BACKEND_PROVIDERS = {"anthropic", "openai-responses", "openai-chat", "openai-oauth", "litellm"}
 VALID_OPENAI_APIS = {"chat", "responses"}
 
 # Intake-agent LLM call budget — seeded into the agent config by ``run`` and
@@ -34,6 +34,7 @@ INTAKE_LLM_RETRY_MAX_DELAY = 2.0
 INTAKE_REASONING_EFFORT = "low"
 
 DEFAULT_OPENAI_MODEL = "gpt-4o"
+DEFAULT_OPENAI_OAUTH_MODEL = "gpt-5"
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-20250514"
 
 # Read-only WebUI: the browser monitor binds here by default for interactive
@@ -59,6 +60,8 @@ def canonical_provider(provider: str | None, openai_api: str | None = None) -> s
         return "anthropic"
     if p == "litellm":
         return "litellm"
+    if p in ("openai-oauth", "chatgpt", "openai_oauth"):
+        return "openai-oauth"
     if p in ("openai-chat", "chat", "openai_compat", "openai_chat"):
         return "openai-chat"
     if p in ("openai-responses", "responses", "openai_responses", "openai_response"):
@@ -76,6 +79,8 @@ def default_model_for_provider(provider: str | None) -> str | None:
     that must persist a concrete string substitute :data:`DEFAULT_CLAUDE_MODEL`.
     """
     canon = canonical_provider(provider)
+    if canon == "openai-oauth":
+        return DEFAULT_OPENAI_OAUTH_MODEL
     if canon.startswith("openai") or canon == "litellm":
         return DEFAULT_OPENAI_MODEL
     return None

--- a/src/cli/_constants.py
+++ b/src/cli/_constants.py
@@ -34,7 +34,7 @@ INTAKE_LLM_RETRY_MAX_DELAY = 2.0
 INTAKE_REASONING_EFFORT = "low"
 
 DEFAULT_OPENAI_MODEL = "gpt-4o"
-DEFAULT_OPENAI_OAUTH_MODEL = "gpt-5"
+DEFAULT_OPENAI_OAUTH_MODEL = "gpt-5.5"
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-20250514"
 
 # Read-only WebUI: the browser monitor binds here by default for interactive

--- a/src/cli/app.py
+++ b/src/cli/app.py
@@ -12,6 +12,7 @@ from .commands.run import run_command
 from .commands.report_cmd import report_command
 from .commands.export_cmd import export_command
 from .commands.config_cmd import config_app
+from .commands.login_cmd import login_app
 from .commands.doctor_cmd import doctor_command
 from .commands.setup_cmd import setup_command
 
@@ -38,6 +39,7 @@ app.command("export")(export_command)
 app.command("doctor")(doctor_command)
 app.command("setup")(setup_command)
 app.add_typer(config_app, name="config")
+app.add_typer(login_app, name="login")
 
 
 @app.command("version")
@@ -51,7 +53,7 @@ def version_command() -> None:
     typer.echo(f"{APP_NAME} {ver}")
 
 
-_KNOWN_COMMANDS = {"run", "report", "export", "config", "version", "doctor", "setup"}
+_KNOWN_COMMANDS = {"run", "report", "export", "config", "version", "doctor", "setup", "login"}
 _ROOT_FLAGS = {"--help", "-h"}
 _VERSION_FLAGS = {"--version", "-V"}
 

--- a/src/cli/commands/login_cmd.py
+++ b/src/cli/commands/login_cmd.py
@@ -1,0 +1,93 @@
+"""`arbor login` — subscription OAuth login (experimental).
+
+Currently supports ChatGPT (OpenAI) subscriptions: ``arbor login openai`` runs a
+browser OAuth flow so Plus/Pro/Team subscribers can drive Arbor with their
+subscription instead of a pay-per-token API key.
+
+Heads-up: using a ChatGPT subscription token with third-party tooling may
+violate OpenAI's terms and can get the account rate-limited or banned. This is
+strictly opt-in.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from ..._app import GLOBAL_CONFIG_FILE
+from .config_cmd import write_user_llm_config
+
+login_app = typer.Typer(
+    name="login",
+    help="Sign in with a model subscription (experimental).",
+    no_args_is_help=True,
+)
+
+
+@login_app.command("openai")
+def login_openai(
+    no_browser: bool = typer.Option(
+        False, "--no-browser",
+        help="Print the auth URL instead of opening a browser.",
+    ),
+    set_default: bool = typer.Option(
+        True, "--set-default/--no-set-default",
+        help="Write provider=openai-oauth to the global config after login.",
+    ),
+) -> None:
+    """Log in to ChatGPT and store the subscription token under ~/.arbor/oauth/."""
+    from ...core.oauth import openai as oauth
+    from ..style import console as _console
+
+    _console.print(
+        "[yellow]Experimental:[/] using a ChatGPT subscription token with "
+        "third-party tools may violate OpenAI's terms and risks your account."
+    )
+    try:
+        tokens = oauth.login(open_browser=not no_browser)
+    except oauth.OAuthError as exc:
+        _console.print(f"[red]login failed:[/] {exc}")
+        raise typer.Exit(code=1)
+
+    plan = tokens.plan_type or "unknown"
+    who = tokens.account_id or "(account id unavailable)"
+    _console.print(f"[green]✓[/] signed in to ChatGPT — plan=[bold]{plan}[/], account={who}")
+
+    if set_default:
+        from .._constants import DEFAULT_OPENAI_OAUTH_MODEL
+
+        model = DEFAULT_OPENAI_OAUTH_MODEL
+        write_user_llm_config({"provider": "openai-oauth", "model": model})
+        _console.print(
+            f"[green]✓[/] set provider=openai-oauth (model={model}) in {GLOBAL_CONFIG_FILE}"
+        )
+    _console.print("Run [bold]arbor[/] to start a session.")
+
+
+@login_app.command("status")
+def login_status() -> None:
+    """Show the current ChatGPT login state."""
+    from ...core.oauth import openai as oauth
+    from ..style import console as _console
+
+    tokens = oauth.load_tokens()
+    if tokens is None:
+        _console.print("[yellow]not signed in[/] — run `arbor login openai`")
+        raise typer.Exit(code=1)
+    plan = tokens.plan_type or "unknown"
+    state = "expired (will refresh)" if tokens.is_expired else "valid"
+    _console.print(
+        f"[green]signed in[/] to ChatGPT — plan=[bold]{plan}[/], "
+        f"account={tokens.account_id or 'unknown'}, access token {state}"
+    )
+
+
+@login_app.command("logout")
+def login_logout() -> None:
+    """Delete the stored ChatGPT subscription token."""
+    from ...core.oauth import openai as oauth
+    from ..style import console as _console
+
+    if oauth.clear_tokens():
+        _console.print("[green]✓[/] removed stored ChatGPT token")
+    else:
+        _console.print("[dim]nothing to remove (not signed in)[/]")

--- a/src/cli/commands/setup_cmd.py
+++ b/src/cli/commands/setup_cmd.py
@@ -48,6 +48,7 @@ def run_setup_wizard(*, force: bool = False) -> bool:
         "                   API and uses it when available, else chat completions\n"
         "  [bold]openai-responses[/bold] OpenAI / o-series via the Responses API (reasoning chain)\n"
         "  [bold]openai-chat[/bold]      any OpenAI-compatible endpoint (DeepSeek / Qwen / GLM / …)\n"
+        "  [bold]openai-oauth[/bold]     ChatGPT Plus/Pro subscription via browser login (experimental)\n"
         "  [bold]anthropic[/bold]        Claude via the native Anthropic API[/]"
     )
     provider = _prompt_choice(
@@ -55,6 +56,9 @@ def run_setup_wizard(*, force: bool = False) -> bool:
         choices=list(PROVIDER_CHOICES),
         default="auto",
     )
+
+    if provider == "openai-oauth":
+        return _setup_openai_oauth()
 
     # 2. base_url (local proxy / vLLM / official API)
     base_url = typer.prompt(
@@ -90,6 +94,36 @@ def run_setup_wizard(*, force: bool = False) -> bool:
         "([dim]view it anytime with[/] [bold]arbor config show[/])."
     )
     _console.print("Just run [bold]arbor[/] to start a session.\n")
+    return True
+
+
+def _setup_openai_oauth() -> bool:
+    """Run the ChatGPT subscription login, then write the global config."""
+    from ...core.oauth import openai as oauth
+    from .._constants import DEFAULT_OPENAI_OAUTH_MODEL
+    from ..style import console as _console
+
+    _console.print()
+    _console.print(
+        "[yellow]Experimental:[/] using a ChatGPT subscription token with "
+        "third-party tools may violate OpenAI's terms and risks your account."
+    )
+    try:
+        tokens = oauth.login()
+    except oauth.OAuthError as exc:
+        _console.print(f"[red]login failed:[/] {exc}")
+        return False
+
+    plan = tokens.plan_type or "unknown"
+    _console.print(f"[green]✓[/] signed in to ChatGPT — plan=[bold]{plan}[/]")
+
+    model = typer.prompt("Model", default=DEFAULT_OPENAI_OAUTH_MODEL).strip() or DEFAULT_OPENAI_OAUTH_MODEL
+    _console.print()
+    write_user_llm_config({"provider": "openai-oauth", "model": model})
+    _console.print(
+        f"\n[green]Done.[/] Saved to [bold]{GLOBAL_CONFIG_FILE}[/]. "
+        "Just run [bold]arbor[/] to start a session.\n"
+    )
     return True
 
 

--- a/src/cli/commands/setup_cmd.py
+++ b/src/cli/commands/setup_cmd.py
@@ -8,6 +8,7 @@ writer (:func:`write_user_llm_config`) so both produce the same file shape.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import typer
@@ -15,7 +16,6 @@ import typer
 from ..._app import GLOBAL_CONFIG_FILE
 from .._constants import (
     DEFAULT_CLAUDE_MODEL,
-    PROVIDER_CHOICES,
     default_model_for_provider,
 )
 from .config_cmd import write_user_llm_config
@@ -42,18 +42,15 @@ def run_setup_wizard(*, force: bool = False) -> bool:
                    f"{GLOBAL_CONFIG_FILE}.[/]\n")
 
     # 1. API type / provider
-    _console.print(
-        "[dim]API type:\n"
-        "  [bold]auto[/bold]             let Arbor detect it — probes the endpoint's Responses\n"
-        "                   API and uses it when available, else chat completions\n"
-        "  [bold]openai-responses[/bold] OpenAI / o-series via the Responses API (reasoning chain)\n"
-        "  [bold]openai-chat[/bold]      any OpenAI-compatible endpoint (DeepSeek / Qwen / GLM / …)\n"
-        "  [bold]openai-oauth[/bold]     ChatGPT Plus/Pro subscription via browser login (experimental)\n"
-        "  [bold]anthropic[/bold]        Claude via the native Anthropic API[/]"
-    )
-    provider = _prompt_choice(
+    provider = _select_choice(
         "API type",
-        choices=list(PROVIDER_CHOICES),
+        options=[
+            ("auto", "let Arbor detect it — probes Responses API, else chat completions"),
+            ("openai-responses", "OpenAI / o-series via the Responses API (reasoning chain)"),
+            ("openai-chat", "any OpenAI-compatible endpoint (DeepSeek / Qwen / GLM / …)"),
+            ("openai-oauth", "ChatGPT Plus/Pro subscription via browser login (experimental)"),
+            ("anthropic", "Claude via the native Anthropic API"),
+        ],
         default="auto",
     )
 
@@ -144,6 +141,100 @@ def _probe_credentials(provider: str, api_key: str | None) -> None:
             _console.print(f"  [dim]{result.hint}[/]")
     else:
         _console.print("[green]✓[/] credentials look resolvable")
+
+
+def _select_choice(
+    label: str, *, options: list[tuple[str, str]], default: str
+) -> str:
+    """Pick one value with arrow keys (↑/↓ or k/j, Enter to confirm).
+
+    ``options`` is a list of ``(value, description)`` pairs. Falls back to a
+    typed prompt when stdin/stdout is not an interactive terminal (CI, pipes,
+    test runners) or when prompt_toolkit cannot start.
+    """
+    values = [value for value, _ in options]
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        return _prompt_choice(label, choices=values, default=default)
+
+    try:
+        return _arrow_select(label, options=options, default=default)
+    except Exception:
+        # Terminal can't host a full prompt_toolkit app — degrade gracefully.
+        return _prompt_choice(label, choices=values, default=default)
+
+
+def _arrow_select(
+    label: str, *, options: list[tuple[str, str]], default: str
+) -> str:
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.styles import Style
+
+    values = [value for value, _ in options]
+    width = max(len(value) for value in values)
+    index = values.index(default) if default in values else 0
+    state = {"index": index}
+
+    def render() -> list[tuple[str, str]]:
+        lines: list[tuple[str, str]] = []
+        for i, (value, desc) in enumerate(options):
+            selected = i == state["index"]
+            pointer = "❯ " if selected else "  "
+            style = "class:option.selected" if selected else "class:option"
+            meta = "class:meta.selected" if selected else "class:meta"
+            lines.append((style, f"{pointer}{value:<{width}}"))
+            lines.append((meta, f"   {desc}\n"))
+        return lines
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("k")
+    def _(event):  # noqa: ANN001
+        state["index"] = (state["index"] - 1) % len(options)
+
+    @kb.add("down")
+    @kb.add("j")
+    def _(event):  # noqa: ANN001
+        state["index"] = (state["index"] + 1) % len(options)
+
+    @kb.add("enter")
+    def _(event):  # noqa: ANN001
+        event.app.exit(result=values[state["index"]])
+
+    @kb.add("c-c")
+    @kb.add("escape")
+    def _(event):  # noqa: ANN001
+        event.app.exit(exception=KeyboardInterrupt)
+
+    header = FormattedTextControl(
+        lambda: [("class:label", f"{label}  "), ("class:hint", "(↑/↓ to move, Enter to select)")]
+    )
+    body = FormattedTextControl(render, focusable=True)
+    layout = Layout(HSplit([
+        Window(header, height=1),
+        Window(body, height=len(options) * 2),
+    ]))
+    style = Style.from_dict({
+        "label": "bold #00afaf",
+        "hint": "#808080",
+        "option": "#d0d0d0",
+        "option.selected": "#d75fff bold",
+        "meta": "#808080",
+        "meta.selected": "#af87ff",
+    })
+    app = Application(layout=layout, key_bindings=kb, style=style, full_screen=False)
+    try:
+        result = app.run()
+    except KeyboardInterrupt:
+        raise typer.Abort() from None
+
+    chosen = next(desc for value, desc in options if value == result)
+    typer.echo(f"{label}: {result}  ({chosen})")
+    return result
 
 
 def _prompt_choice(label: str, *, choices: list[str], default: str) -> str:

--- a/src/cli/commands/setup_cmd.py
+++ b/src/cli/commands/setup_cmd.py
@@ -82,6 +82,9 @@ def run_setup_wizard(*, force: bool = False) -> bool:
     if api_key:
         llm["api_key"] = api_key
 
+    # 5. reasoning effort (reasoning models / Claude thinking budget)
+    llm["reasoning_effort"] = _prompt_reasoning_effort()
+
     _console.print()
     write_user_llm_config(llm)
 
@@ -115,8 +118,11 @@ def _setup_openai_oauth() -> bool:
     _console.print(f"[green]✓[/] signed in to ChatGPT — plan=[bold]{plan}[/]")
 
     model = typer.prompt("Model", default=DEFAULT_OPENAI_OAUTH_MODEL).strip() or DEFAULT_OPENAI_OAUTH_MODEL
+    effort = _prompt_reasoning_effort(default="medium")
     _console.print()
-    write_user_llm_config({"provider": "openai-oauth", "model": model})
+    write_user_llm_config(
+        {"provider": "openai-oauth", "model": model, "reasoning_effort": effort}
+    )
     _console.print(
         f"\n[green]Done.[/] Saved to [bold]{GLOBAL_CONFIG_FILE}[/]. "
         "Just run [bold]arbor[/] to start a session.\n"
@@ -141,6 +147,20 @@ def _probe_credentials(provider: str, api_key: str | None) -> None:
             _console.print(f"  [dim]{result.hint}[/]")
     else:
         _console.print("[green]✓[/] credentials look resolvable")
+
+
+def _prompt_reasoning_effort(default: str = "high") -> str:
+    """Pick the reasoning effort (speed vs. depth) for the run loop."""
+    return _select_choice(
+        "Reasoning effort",
+        options=[
+            ("high", "most thorough planning — slowest (best quality)"),
+            ("medium", "balanced depth and speed"),
+            ("low", "light reasoning — fast, may weaken complex planning"),
+            ("none", "no reasoning — fastest, lowest quality"),
+        ],
+        default=default,
+    )
 
 
 def _select_choice(

--- a/src/cli/preflight.py
+++ b/src/cli/preflight.py
@@ -117,6 +117,9 @@ class PreflightChecker:
     }
 
     def _check_llm(self) -> CheckResult:
+        if self.provider == "openai-oauth":
+            return self._check_openai_oauth()
+
         if self.provider not in self._PROVIDER_ENV:
             return CheckResult(
                 "llm", "fail",
@@ -154,6 +157,27 @@ class PreflightChecker:
             f"missing {expected} for provider={self.provider}",
             hint=f"export {primary}=... or run `arbor setup`",
         )
+
+    @staticmethod
+    def _check_openai_oauth() -> CheckResult:
+        """ChatGPT subscription auth lives in a token file, not an env var."""
+        try:
+            from ..core.oauth import openai as oauth
+        except ImportError:
+            return CheckResult(
+                "llm", "fail", "openai oauth support unavailable",
+                hint="reinstall arbor",
+            )
+        tokens = oauth.load_tokens()
+        if tokens is None:
+            return CheckResult(
+                "llm", "fail",
+                "not logged in to ChatGPT (provider=openai-oauth)",
+                hint="run `arbor login openai`",
+            )
+        plan = tokens.plan_type or "unknown"
+        return CheckResult("llm", "pass",
+                           f"ChatGPT subscription token found (plan={plan})")
 
     # ── Check 2: codebase ──────────────────────────────────────────
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -32,14 +32,17 @@ __all__ = [
 def resolve_backend(provider: str | None, openai_api: str | None, model: str | None, base_url: str | None) -> str:
     """Collapse the (provider, openai_api) config onto one backend id.
 
-    Returns one of: ``anthropic`` | ``openai-responses`` | ``openai-chat`` |
-    ``litellm``. ``provider="auto"`` (the default) routes by model name:
+    Returns one of: ``anthropic`` | ``openai-oauth`` | ``openai-responses`` |
+    ``openai-chat`` | ``litellm``. ``provider="auto"`` (the default) routes by
+    model name:
     a ``claude*`` model on the default endpoint uses the native Anthropic
     backend (prompt caching); everything else uses litellm.
     """
     p = (provider or "auto").lower()
     if p in ("claude", "anthropic"):
         return "anthropic"
+    if p in ("openai-oauth", "chatgpt", "openai_oauth"):
+        return "openai-oauth"
     if p in ("openai-responses", "responses"):
         return "openai-responses"
     if p in ("openai-chat", "openai_compat", "chat"):
@@ -73,6 +76,17 @@ def create_provider(config: AgentConfig) -> LLMProvider:
             timeout=config.llm_timeout,
             reasoning_effort=config.reasoning_effort,
             thinking_budget_tokens=config.thinking_budget_tokens,
+        )
+    if backend == "openai-oauth":
+        from .llm.openai_oauth import OpenAIOAuthProvider
+        return OpenAIOAuthProvider(
+            model=config.model,
+            max_retries=config.llm_provider_retries,
+            timeout=config.llm_timeout,
+            reasoning_effort=config.reasoning_effort,
+            reasoning_summary=config.reasoning_summary,
+            text_verbosity=config.text_verbosity,
+            parallel_tool_calls=config.parallel_tool_calls,
         )
     if backend == "openai-responses":
         from .llm.openai_responses import OpenAIResponsesProvider

--- a/src/core/config_cli.py
+++ b/src/core/config_cli.py
@@ -44,7 +44,7 @@ class CLIField:
 # the groups they expose, so a shared field (e.g. --provider) is declared once.
 
 LLM_FLAGS: tuple[CLIField, ...] = (
-    CLIField("--provider", "provider", str, "Backend: auto (default) | anthropic | openai-responses | openai-chat | litellm", choices=("auto", "anthropic", "claude", "openai", "openai-responses", "openai-chat", "litellm")),
+    CLIField("--provider", "provider", str, "Backend: auto (default) | anthropic | openai-responses | openai-chat | openai-oauth | litellm", choices=("auto", "anthropic", "claude", "openai", "openai-responses", "openai-chat", "openai-oauth", "litellm")),
     CLIField("--model", "model", str, "Model name (default: claude-sonnet-4-20250514 / gpt-4o)"),
     CLIField("--api-key", "api_key", str, "API key (default: from env)"),
     CLIField("--base-url", "base_url", str, "Custom API base URL (vLLM, Ollama, proxy, ...)"),

--- a/src/core/llm/openai_oauth.py
+++ b/src/core/llm/openai_oauth.py
@@ -1,0 +1,95 @@
+"""ChatGPT-subscription Responses provider (experimental).
+
+Authenticates with an OAuth access token obtained via ``arbor login openai``
+and targets the ChatGPT backend (``chatgpt.com/backend-api/codex``) instead of
+the pay-per-token ``api.openai.com`` endpoint. Everything else — message
+conversion, reasoning replay, tool calls, parsing — is inherited from
+:class:`OpenAIResponsesProvider`.
+
+Tokens are refreshed transparently before each call. Using a ChatGPT
+subscription token with third-party tooling may violate OpenAI's terms; this
+backend is strictly opt-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from openai import AsyncOpenAI
+
+from ..oauth import openai as oauth
+from .base import LLMResponse
+from .openai_responses import OpenAIResponsesProvider
+
+
+class OpenAIOAuthProvider(OpenAIResponsesProvider):
+    """Responses provider backed by a ChatGPT subscription OAuth token."""
+
+    def __init__(
+        self,
+        model: str = "gpt-5",
+        *,
+        max_retries: int = 3,
+        timeout: float = 300.0,
+        reasoning_effort: str | None = "high",
+        reasoning_summary: str | None = "auto",
+        text_verbosity: str | None = "medium",
+        parallel_tool_calls: bool | None = True,
+        **_ignored: Any,
+    ) -> None:
+        tokens = oauth.get_valid_tokens()
+        self._max_retries = max_retries
+        self._access_token = tokens.access_token
+        self._account_id = tokens.account_id
+        super().__init__(
+            model=model,
+            api_key=tokens.access_token,
+            base_url=oauth.CHATGPT_RESPONSES_BASE_URL,
+            max_retries=max_retries,
+            timeout=timeout,
+            reasoning_effort=reasoning_effort,
+            reasoning_summary=reasoning_summary,
+            text_verbosity=text_verbosity,
+            parallel_tool_calls=parallel_tool_calls,
+        )
+        # Replace the vanilla client built by the base class with one carrying
+        # the ChatGPT backend's required routing headers.
+        self._rebuild_client(tokens.access_token)
+
+    def _rebuild_client(self, access_token: str) -> None:
+        self._client = AsyncOpenAI(
+            api_key=access_token,
+            base_url=oauth.CHATGPT_RESPONSES_BASE_URL,
+            max_retries=self._max_retries,
+            timeout=self.timeout,
+            default_headers={
+                "chatgpt-account-id": self._account_id,
+                "originator": "codex_cli_rs",
+                "OpenAI-Beta": "responses=experimental",
+            },
+        )
+
+    async def _ensure_fresh(self) -> None:
+        """Refresh the token if it is near expiry, rebuilding the client once."""
+        tokens = await asyncio.to_thread(oauth.get_valid_tokens)
+        if tokens.access_token != self._access_token:
+            self._access_token = tokens.access_token
+            self._account_id = tokens.account_id
+            self._rebuild_client(tokens.access_token)
+
+    async def create(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 16384,
+    ) -> LLMResponse:
+        await self._ensure_fresh()
+        return await super().create(
+            system=system,
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+        )

--- a/src/core/llm/openai_oauth.py
+++ b/src/core/llm/openai_oauth.py
@@ -14,6 +14,7 @@ backend is strictly opt-in.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 
 from openai import AsyncOpenAI
@@ -28,7 +29,7 @@ class OpenAIOAuthProvider(OpenAIResponsesProvider):
 
     def __init__(
         self,
-        model: str = "gpt-5",
+        model: str = "gpt-5.5",
         *,
         max_retries: int = 3,
         timeout: float = 300.0,
@@ -87,9 +88,40 @@ class OpenAIOAuthProvider(OpenAIResponsesProvider):
         max_tokens: int = 16384,
     ) -> LLMResponse:
         await self._ensure_fresh()
-        return await super().create(
-            system=system,
-            messages=messages,
-            tools=tools,
-            max_tokens=max_tokens,
+        params = self._build_request_params(
+            system=system, messages=messages, tools=tools, max_tokens=max_tokens,
         )
+        # The ChatGPT codex backend rejects non-streaming Responses calls
+        # ("Stream must be set to true"), so we always stream and reassemble the
+        # final response object — callers still get a single LLMResponse.
+        params["stream"] = True
+        # The codex backend does not accept ``max_output_tokens`` ("Unsupported
+        # parameter"); it manages the output budget itself.
+        params.pop("max_output_tokens", None)
+
+        # The codex backend streams completed items via ``output_item.done`` but
+        # leaves ``response.completed.response.output`` empty, so we collect the
+        # items ourselves rather than relying on the terminal payload.
+        stream = await self._client.responses.create(**params)
+        collected: list[Any] = []
+        final = None
+        async for event in stream:
+            etype = getattr(event, "type", None)
+            if etype == "response.output_item.done":
+                collected.append(event.item)
+            elif etype == "response.completed":
+                final = event.response
+        if final is None:
+            raise RuntimeError(
+                "ChatGPT backend stream ended without a completed response"
+            )
+
+        shim = SimpleNamespace(
+            output=collected,
+            usage=getattr(final, "usage", None),
+            model=getattr(final, "model", None),
+            status=getattr(final, "status", None),
+            incomplete_details=getattr(final, "incomplete_details", None),
+            output_text=getattr(final, "output_text", "") or "",
+        )
+        return self._parse_response(shim)

--- a/src/core/llm/openai_responses.py
+++ b/src/core/llm/openai_responses.py
@@ -72,6 +72,20 @@ class OpenAIResponsesProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         max_tokens: int = 16384,
     ) -> LLMResponse:
+        params = self._build_request_params(
+            system=system, messages=messages, tools=tools, max_tokens=max_tokens,
+        )
+        raw = await self._client.responses.create(**params)
+        return self._parse_response(raw)
+
+    def _build_request_params(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
         input_items = self._convert_messages(messages)
 
         params: dict[str, Any] = {
@@ -103,8 +117,7 @@ class OpenAIResponsesProvider(LLMProvider):
             if self.parallel_tool_calls is not None:
                 params["parallel_tool_calls"] = self.parallel_tool_calls
 
-        raw = await self._client.responses.create(**params)
-        return self._parse_response(raw)
+        return params
 
     def count_tokens(self, text: str) -> int:
         return len(self._enc.encode(text))

--- a/src/core/oauth/__init__.py
+++ b/src/core/oauth/__init__.py
@@ -1,0 +1,6 @@
+"""Subscription OAuth helpers (experimental).
+
+Currently hosts the ChatGPT (OpenAI) subscription login flow so Plus/Pro/Team
+subscribers can drive Arbor with their subscription instead of a pay-per-token
+API key. See :mod:`arbor.core.oauth.openai`.
+"""

--- a/src/core/oauth/openai.py
+++ b/src/core/oauth/openai.py
@@ -24,7 +24,6 @@ import urllib.parse
 import webbrowser
 from dataclasses import asdict, dataclass
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from pathlib import Path
 from typing import Any
 
 import httpx

--- a/src/core/oauth/openai.py
+++ b/src/core/oauth/openai.py
@@ -1,0 +1,319 @@
+"""ChatGPT (OpenAI) subscription OAuth — login, token storage, refresh.
+
+EXPERIMENTAL / UNSUPPORTED. Replicates the Codex CLI OAuth (PKCE) flow so that
+ChatGPT Plus/Pro/Team subscribers can drive Arbor with their subscription
+instead of a pay-per-token ``OPENAI_API_KEY``. The obtained access token is
+sent to the ChatGPT backend (``chatgpt.com/backend-api/codex``) by
+:class:`arbor.core.llm.openai_oauth.OpenAIOAuthProvider`.
+
+Tokens live in ``~/.arbor/oauth/openai.json`` (chmod 600). Using a ChatGPT
+subscription token with third-party tooling may violate OpenAI's terms and can
+get the account rate-limited or banned; this path is strictly opt-in.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+import urllib.parse
+import webbrowser
+from dataclasses import asdict, dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from ..._app import GLOBAL_CONFIG_DIR
+
+# ── Public constants (verified against openai/codex) ─────────────────────────
+ISSUER = "https://auth.openai.com"
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+REDIRECT_PORT = 1455
+REDIRECT_URI = f"http://localhost:{REDIRECT_PORT}/auth/callback"
+SCOPES = "openid profile email offline_access"
+# The ChatGPT subscription backend speaks the Responses API at /codex/responses.
+# The OpenAI SDK appends "/responses" to this base_url.
+CHATGPT_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+TOKEN_PATH = GLOBAL_CONFIG_DIR / "oauth" / "openai.json"
+
+# Refresh proactively this many seconds before the access token expires.
+_REFRESH_SKEW = 300
+# Default access-token lifetime when the issuer omits ``expires_in``.
+_DEFAULT_EXPIRES_IN = 3600
+
+
+class OAuthError(RuntimeError):
+    """Raised for any failure in the login / refresh flow."""
+
+
+@dataclass
+class OpenAITokens:
+    access_token: str
+    refresh_token: str
+    id_token: str = ""
+    account_id: str = ""
+    plan_type: str = ""
+    expires_at: float = 0.0
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= (self.expires_at - _REFRESH_SKEW)
+
+
+# ── Low-level encoding helpers ───────────────────────────────────────────────
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _decode_jwt_claims(jwt: str) -> dict[str, Any]:
+    """Decode a JWT payload without signature verification.
+
+    We only read non-sensitive routing claims (account id, plan type); the
+    token's authority is enforced by the server on every request, so local
+    verification adds nothing here.
+    """
+    try:
+        payload = jwt.split(".")[1]
+        payload += "=" * (-len(payload) % 4)  # restore base64 padding
+        return json.loads(base64.urlsafe_b64decode(payload))
+    except (IndexError, ValueError, json.JSONDecodeError):
+        return {}
+
+
+def _account_info(id_token: str) -> tuple[str, str]:
+    """Extract ``(account_id, plan_type)`` from an id_token's auth claim."""
+    claims = _decode_jwt_claims(id_token)
+    auth = claims.get("https://api.openai.com/auth", {})
+    if not isinstance(auth, dict):
+        return "", ""
+    account_id = str(auth.get("chatgpt_account_id") or "")
+    plan_type = str(auth.get("chatgpt_plan_type") or "")
+    return account_id, plan_type
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = _b64url(secrets.token_bytes(64))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# ── Token persistence ────────────────────────────────────────────────────────
+
+def load_tokens() -> OpenAITokens | None:
+    """Return stored tokens, or ``None`` if the user has not logged in."""
+    if not TOKEN_PATH.exists():
+        return None
+    try:
+        data = json.loads(TOKEN_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not data.get("access_token") or not data.get("refresh_token"):
+        return None
+    known = {f for f in OpenAITokens.__dataclass_fields__}
+    return OpenAITokens(**{k: v for k, v in data.items() if k in known})
+
+
+def save_tokens(tokens: OpenAITokens) -> None:
+    TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    TOKEN_PATH.write_text(json.dumps(asdict(tokens), indent=2), encoding="utf-8")
+    try:
+        os.chmod(TOKEN_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def clear_tokens() -> bool:
+    """Delete stored tokens. Returns True if a file was removed."""
+    if TOKEN_PATH.exists():
+        TOKEN_PATH.unlink()
+        return True
+    return False
+
+
+# ── HTTP token exchange / refresh ────────────────────────────────────────────
+
+def _post_token(form: dict[str, str]) -> dict[str, Any]:
+    url = f"{ISSUER}/oauth/token"
+    try:
+        resp = httpx.post(
+            url,
+            data=form,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        raise OAuthError(f"token endpoint request failed: {exc}") from exc
+    if resp.status_code != 200:
+        raise OAuthError(
+            f"token endpoint returned {resp.status_code}: {resp.text[:300]}"
+        )
+    return resp.json()
+
+
+def _tokens_from_response(data: dict[str, Any], *, fallback_refresh: str = "") -> OpenAITokens:
+    access_token = data.get("access_token") or ""
+    if not access_token:
+        raise OAuthError("token response missing access_token")
+    refresh_token = data.get("refresh_token") or fallback_refresh
+    id_token = data.get("id_token") or ""
+    account_id, plan_type = _account_info(id_token) if id_token else ("", "")
+    expires_in = int(data.get("expires_in") or _DEFAULT_EXPIRES_IN)
+    return OpenAITokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        id_token=id_token,
+        account_id=account_id,
+        plan_type=plan_type,
+        expires_at=time.time() + expires_in,
+    )
+
+
+def refresh(tokens: OpenAITokens) -> OpenAITokens:
+    """Exchange the refresh token for a fresh access token and persist it."""
+    if not tokens.refresh_token:
+        raise OAuthError("no refresh token available; run `arbor login openai` again")
+    data = _post_token({
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": tokens.refresh_token,
+        "scope": SCOPES,
+    })
+    refreshed = _tokens_from_response(data, fallback_refresh=tokens.refresh_token)
+    # The refresh response often omits id_token; keep the previously known
+    # account/plan so requests still carry the chatgpt-account-id header.
+    if not refreshed.account_id:
+        refreshed.account_id = tokens.account_id
+        refreshed.plan_type = tokens.plan_type or refreshed.plan_type
+        if not refreshed.id_token:
+            refreshed.id_token = tokens.id_token
+    save_tokens(refreshed)
+    return refreshed
+
+
+def get_valid_tokens() -> OpenAITokens:
+    """Load tokens, refreshing if they are expired. Raises if not logged in."""
+    tokens = load_tokens()
+    if tokens is None:
+        raise OAuthError(
+            "not logged in to ChatGPT — run `arbor login openai`"
+        )
+    if tokens.is_expired:
+        tokens = refresh(tokens)
+    return tokens
+
+
+# ── Browser login flow ───────────────────────────────────────────────────────
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """One-shot handler that captures the ``?code=&state=`` redirect."""
+
+    result: dict[str, str] = {}
+    event: threading.Event | None = None
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib signature)
+        parsed = urllib.parse.urlparse(self.path)
+        if not parsed.path.startswith("/auth/callback"):
+            self.send_response(404)
+            self.end_headers()
+            return
+        params = urllib.parse.parse_qs(parsed.query)
+        type(self).result = {
+            "code": (params.get("code") or [""])[0],
+            "state": (params.get("state") or [""])[0],
+            "error": (params.get("error") or [""])[0],
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.end_headers()
+        self.wfile.write(
+            b"<html><body style='font-family:sans-serif;text-align:center;"
+            b"margin-top:4rem'><h2>Arbor is now signed in to ChatGPT.</h2>"
+            b"<p>You can close this tab and return to the terminal.</p>"
+            b"</body></html>"
+        )
+        if type(self).event is not None:
+            type(self).event.set()
+
+    def log_message(self, *_args: Any) -> None:  # silence stdlib logging
+        return
+
+
+def _authorize_url(challenge: str, state: str) -> str:
+    query = urllib.parse.urlencode({
+        "response_type": "code",
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "id_token_add_organizations": "true",
+        "codex_cli_simplified_flow": "true",
+        "state": state,
+    })
+    return f"{ISSUER}/oauth/authorize?{query}"
+
+
+def login(*, open_browser: bool = True, timeout: float = 300.0) -> OpenAITokens:
+    """Run the interactive browser OAuth flow and persist the tokens.
+
+    Spins up a localhost callback server on :data:`REDIRECT_PORT`, opens the
+    authorization URL, waits for the redirect, exchanges the code (PKCE), and
+    saves the resulting tokens. Returns the stored :class:`OpenAITokens`.
+    """
+    verifier, challenge = _pkce()
+    state = _b64url(secrets.token_bytes(16))
+
+    event = threading.Event()
+    _CallbackHandler.result = {}
+    _CallbackHandler.event = event
+    try:
+        server = HTTPServer(("127.0.0.1", REDIRECT_PORT), _CallbackHandler)
+    except OSError as exc:
+        raise OAuthError(
+            f"cannot bind localhost:{REDIRECT_PORT} for the OAuth callback "
+            f"({exc}). Close whatever is using that port and retry."
+        ) from exc
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        url = _authorize_url(challenge, state)
+        opened = webbrowser.open(url) if open_browser else False
+        print("\nOpen this URL to authorize Arbor with your ChatGPT account:")
+        print(f"\n  {url}\n")
+        if not opened:
+            print("(Could not auto-open a browser; paste the URL above.)\n")
+        if not event.wait(timeout):
+            raise OAuthError("timed out waiting for the OAuth callback")
+    finally:
+        server.shutdown()
+        server.server_close()
+        _CallbackHandler.event = None
+
+    result = _CallbackHandler.result
+    if result.get("error"):
+        raise OAuthError(f"authorization denied: {result['error']}")
+    if result.get("state") != state:
+        raise OAuthError("OAuth state mismatch — aborting (possible CSRF)")
+    code = result.get("code") or ""
+    if not code:
+        raise OAuthError("no authorization code returned")
+
+    data = _post_token({
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    })
+    tokens = _tokens_from_response(data)
+    save_tokens(tokens)
+    return tokens

--- a/tests/test_openai_oauth.py
+++ b/tests/test_openai_oauth.py
@@ -1,0 +1,136 @@
+"""Tests for the experimental ChatGPT subscription OAuth backend."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+
+from arbor.core import resolve_backend
+from arbor.core.oauth import openai as oauth
+from arbor.cli._constants import canonical_provider, default_model_for_provider
+
+
+def _fake_jwt(account_id: str = "acc-123", plan: str = "pro") -> str:
+    def b64(obj: dict) -> str:
+        raw = json.dumps(obj).encode()
+        return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+    header = b64({"alg": "none", "typ": "JWT"})
+    payload = b64({
+        "email": "user@example.com",
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id,
+            "chatgpt_plan_type": plan,
+        },
+    })
+    return f"{header}.{payload}.sig"
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+def test_resolve_backend_recognizes_oauth():
+    assert resolve_backend("openai-oauth", None, "gpt-5", None) == "openai-oauth"
+    assert resolve_backend("chatgpt", None, "gpt-5", None) == "openai-oauth"
+
+
+def test_canonical_and_default_model():
+    assert canonical_provider("openai-oauth") == "openai-oauth"
+    assert canonical_provider("chatgpt") == "openai-oauth"
+    assert default_model_for_provider("openai-oauth") == "gpt-5"
+
+
+# ── JWT claim parsing ────────────────────────────────────────────────────────
+
+def test_account_info_from_id_token():
+    account_id, plan = oauth._account_info(_fake_jwt("acc-xyz", "team"))
+    assert account_id == "acc-xyz"
+    assert plan == "team"
+
+
+def test_account_info_malformed_is_empty():
+    assert oauth._account_info("not-a-jwt") == ("", "")
+
+
+# ── Token persistence ────────────────────────────────────────────────────────
+
+def test_save_load_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "oauth" / "openai.json")
+    tokens = oauth.OpenAITokens(
+        access_token="at", refresh_token="rt", account_id="acc", plan_type="pro",
+        expires_at=time.time() + 3600,
+    )
+    oauth.save_tokens(tokens)
+    loaded = oauth.load_tokens()
+    assert loaded is not None
+    assert loaded.access_token == "at"
+    assert loaded.account_id == "acc"
+    assert not loaded.is_expired
+    assert oauth.clear_tokens() is True
+    assert oauth.load_tokens() is None
+
+
+def test_load_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "nope.json")
+    assert oauth.load_tokens() is None
+
+
+# ── Refresh ──────────────────────────────────────────────────────────────────
+
+def test_refresh_preserves_account_when_id_token_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "openai.json")
+    monkeypatch.setattr(oauth, "_post_token", lambda form: {
+        "access_token": "new-at", "expires_in": 3600,
+        # no refresh_token, no id_token in the refresh response
+    })
+    old = oauth.OpenAITokens(
+        access_token="old", refresh_token="rt", account_id="acc-keep",
+        plan_type="pro", id_token=_fake_jwt("acc-keep", "pro"), expires_at=0,
+    )
+    refreshed = oauth.refresh(old)
+    assert refreshed.access_token == "new-at"
+    assert refreshed.refresh_token == "rt"        # fell back to the old one
+    assert refreshed.account_id == "acc-keep"     # preserved across refresh
+    assert refreshed.plan_type == "pro"
+
+
+def test_get_valid_tokens_refreshes_when_expired(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "openai.json")
+    expired = oauth.OpenAITokens(
+        access_token="old", refresh_token="rt", account_id="acc",
+        plan_type="pro", expires_at=0,
+    )
+    oauth.save_tokens(expired)
+    monkeypatch.setattr(oauth, "_post_token", lambda form: {
+        "access_token": "fresh", "refresh_token": "rt2", "expires_in": 3600,
+    })
+    tokens = oauth.get_valid_tokens()
+    assert tokens.access_token == "fresh"
+
+
+def test_get_valid_tokens_raises_when_logged_out(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "openai.json")
+    with pytest.raises(oauth.OAuthError):
+        oauth.get_valid_tokens()
+
+
+# ── Provider wiring ──────────────────────────────────────────────────────────
+
+def test_provider_builds_chatgpt_client(monkeypatch):
+    from arbor.core.llm.openai_oauth import OpenAIOAuthProvider
+
+    fake = oauth.OpenAITokens(
+        access_token="tok", refresh_token="rt", account_id="acc-1",
+        plan_type="pro", expires_at=time.time() + 3600,
+    )
+    monkeypatch.setattr(oauth, "get_valid_tokens", lambda: fake)
+
+    provider = OpenAIOAuthProvider(model="gpt-5")
+    assert provider.base_url == oauth.CHATGPT_RESPONSES_BASE_URL
+    assert provider._account_id == "acc-1"
+    assert provider._access_token == "tok"
+    # The backend routing header must be present on the client.
+    headers = provider._client.default_headers
+    assert headers.get("chatgpt-account-id") == "acc-1"

--- a/tests/test_openai_oauth.py
+++ b/tests/test_openai_oauth.py
@@ -39,7 +39,7 @@ def test_resolve_backend_recognizes_oauth():
 def test_canonical_and_default_model():
     assert canonical_provider("openai-oauth") == "openai-oauth"
     assert canonical_provider("chatgpt") == "openai-oauth"
-    assert default_model_for_provider("openai-oauth") == "gpt-5"
+    assert default_model_for_provider("openai-oauth") == "gpt-5.5"
 
 
 # ── JWT claim parsing ────────────────────────────────────────────────────────
@@ -134,3 +134,61 @@ def test_provider_builds_chatgpt_client(monkeypatch):
     # The backend routing header must be present on the client.
     headers = provider._client.default_headers
     assert headers.get("chatgpt-account-id") == "acc-1"
+
+
+def test_create_reassembles_streamed_items(monkeypatch):
+    """The codex backend leaves completed.output empty and streams items via
+    ``output_item.done``; create() must collect those into the response."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from arbor.core.llm.openai_oauth import OpenAIOAuthProvider
+
+    fake = oauth.OpenAITokens(
+        access_token="tok", refresh_token="rt", account_id="acc-1",
+        plan_type="pro", expires_at=time.time() + 3600,
+    )
+    monkeypatch.setattr(oauth, "get_valid_tokens", lambda: fake)
+    provider = OpenAIOAuthProvider(model="gpt-5.5")
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.done",
+            item={"type": "function_call", "call_id": "call_1",
+                  "name": "get_weather", "arguments": '{"city": "Paris"}'},
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(
+                output=[],  # codex leaves this empty on purpose
+                usage=SimpleNamespace(input_tokens=12, output_tokens=7),
+                model="gpt-5.5", status="completed",
+                incomplete_details=None, output_text="",
+            ),
+        ),
+    ]
+
+    async def fake_create(**params):
+        assert params["stream"] is True
+        assert "max_output_tokens" not in params  # codex rejects it
+
+        async def gen():
+            for ev in events:
+                yield ev
+
+        return gen()
+
+    provider._client.responses.create = fake_create  # type: ignore[assignment]
+
+    result = asyncio.run(provider.create(
+        system="s", messages=[{"role": "user", "content": "weather in Paris?"}],
+        tools=[{"name": "get_weather", "description": "w",
+                "input_schema": {"type": "object", "properties": {}}}],
+    ))
+
+    assert result.stop_reason == "tool_use"
+    tool_calls = [b for b in result.content if getattr(b, "name", None) == "get_weather"]
+    assert tool_calls and tool_calls[0].input == {"city": "Paris"}
+    assert result.usage.input_tokens == 12
+    assert result.usage.output_tokens == 7
+

--- a/uv.lock
+++ b/uv.lock
@@ -222,6 +222,7 @@ name = "arbor-agent"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "httpx" },
     { name = "litellm" },
     { name = "openai" },
     { name = "prompt-toolkit" },
@@ -250,6 +251,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.52.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.55.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocs-static-i18n", marker = "extra == 'docs'", specifier = ">=1.2" },


### PR DESCRIPTION
## Summary / 概述

Adds an **experimental, opt-in** ChatGPT subscription OAuth backend so Plus/Pro/Team subscribers can drive Arbor with their subscription instead of a pay-per-token `OPENAI_API_KEY`, plus a reasoning-effort selector in the setup wizard.

> ⚠️ **Experimental / unsupported.** Using a ChatGPT subscription token with third-party tooling may violate OpenAI's terms and can get the account rate-limited or banned. Strictly opt-in.

## What's included / 改动内容

- **OAuth (PKCE) login flow** — `arbor login openai` / `status` / `logout`. Tokens stored at `~/.arbor/oauth/openai.json` (chmod 600), proactive refresh with skew.
- **`OpenAIOAuthProvider`** — targets the ChatGPT codex backend (`chatgpt.com/backend-api/codex`); reuses `OpenAIResponsesProvider` message/tool/reasoning handling via an extracted `_build_request_params`. Streams + reassembles (the codex backend rejects non-streaming and `max_output_tokens`).
- **Provider routing** — `provider: openai-oauth` (aliases `chatgpt`) wired through `resolve_backend` / `create_provider`.
- **Setup wizard** — arrow-key API-type selection and a reasoning-effort selector (high/medium/low/none) on both API-key and OAuth paths; `reasoning_effort` is persisted and flows through to the request `reasoning.effort`.
- Docs (`configuration.md` + zh), `httpx` dependency + `uv.lock` sync, and tests.

## How tested / 验证

- `pytest` — full suite green (147 passed), incl. new `tests/test_openai_oauth.py` (routing, JWT claim parsing, token persistence, refresh-preserves-account, stream reassembly).
- Verified `reasoning_effort` (high/medium/low/none) flows through to the OAuth provider's request params; `none` is normalized to "omit" by the config validator.

## Notes / 已知点

- **Token-file concurrency**: parallel executors each refresh and write the same token file without a lock; if the issuer rotates refresh tokens, concurrent refreshes could race. Acceptable for the experimental path; a file-lock/single-flight is a sensible follow-up.
- Real codex-backend behavior (e.g. whether effort changes output) can only be confirmed with a live ChatGPT token.

## Type / 类型
- [x] ✨ Feature (`feat`) — experimental
