### PR TITLE
feat: add experimental Claude subscription OAuth backend

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,26 @@ three:
     get your account rate-limited or banned. This path is opt-in and unsupported — prefer a
     standard `OPENAI_API_KEY` for anything you care about.
 
+!!! warning "Experimental: Claude subscription login (`anthropic-oauth`)"
+    Claude Pro/Max subscribers can drive Arbor with their subscription instead of a
+    pay-per-token key. Run `arbor login claude` to sign in through the browser, then paste
+    the code the callback page shows; the token is stored in `~/.arbor/oauth/anthropic.json`
+    and refreshed automatically. This writes:
+
+    ```yaml
+    llm:
+      provider: anthropic-oauth
+      model: claude-sonnet-4-5-20250929
+    ```
+
+    Manage the session with `arbor login status` / `arbor login logout`. Requests go to the
+    Anthropic Messages API as a `Bearer` token (with the `anthropic-beta: oauth-2025-04-20`
+    header), **not** with an `x-api-key`.
+
+    Using a subscription token with third-party tooling may violate Anthropic's terms and can
+    get your account rate-limited or banned. This path is opt-in and unsupported — prefer a
+    standard `ANTHROPIC_API_KEY` for anything you care about.
+
 ### 3. Per-project: a config file
 
 When a project needs its own durable settings, drop a YAML file in it. Arbor auto-detects

--- a/src/cli/_constants.py
+++ b/src/cli/_constants.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 # display order. Each is a single-axis value that maps 1:1 onto a backend, so
 # the config file reads the same as the menu. `auto` resolves to one of the
 # concrete three at setup time.
-PROVIDER_CHOICES = ("auto", "openai-responses", "openai-chat", "openai-oauth", "anthropic")
+PROVIDER_CHOICES = ("auto", "openai-responses", "openai-chat", "openai-oauth", "anthropic", "anthropic-oauth")
 
 # Concrete providers Arbor can store + serve after `auto` is resolved. `litellm`
 # stays a valid backend for back-compat / advanced hand-edited configs, but is
 # no longer advertised in the menu.
-_BACKEND_PROVIDERS = {"anthropic", "openai-responses", "openai-chat", "openai-oauth", "litellm"}
+_BACKEND_PROVIDERS = {"anthropic", "anthropic-oauth", "openai-responses", "openai-chat", "openai-oauth", "litellm"}
 VALID_OPENAI_APIS = {"chat", "responses"}
 
 # Intake-agent LLM call budget — seeded into the agent config by ``run`` and
@@ -39,6 +39,9 @@ INTAKE_REASONING_EFFORT = "low"
 DEFAULT_OPENAI_MODEL = "gpt-4o"
 DEFAULT_OPENAI_OAUTH_MODEL = "gpt-5.5"
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-20250514"
+# The subscription (OAuth) backend exposes only current snapshots; the dated
+# API-key default above is retired there, so use a live one.
+DEFAULT_CLAUDE_OAUTH_MODEL = "claude-sonnet-4-5-20250929"
 
 # Read-only WebUI: the browser monitor binds here by default for interactive
 # runs (no flag needed). If the port is taken we walk the next few ports so a
@@ -61,6 +64,8 @@ def canonical_provider(provider: str | None, openai_api: str | None = None) -> s
         return "auto"
     if p in ("claude", "anthropic"):
         return "anthropic"
+    if p in ("anthropic-oauth", "claude-oauth", "claude-pro", "anthropic_oauth"):
+        return "anthropic-oauth"
     if p == "litellm":
         return "litellm"
     if p in ("openai-oauth", "chatgpt", "openai_oauth"):
@@ -84,6 +89,8 @@ def default_model_for_provider(provider: str | None) -> str | None:
     canon = canonical_provider(provider)
     if canon == "openai-oauth":
         return DEFAULT_OPENAI_OAUTH_MODEL
+    if canon == "anthropic-oauth":
+        return DEFAULT_CLAUDE_OAUTH_MODEL
     if canon.startswith("openai") or canon == "litellm":
         return DEFAULT_OPENAI_MODEL
     return None

--- a/src/cli/commands/login_cmd.py
+++ b/src/cli/commands/login_cmd.py
@@ -1,11 +1,11 @@
 """`arbor login` — subscription OAuth login (experimental).
 
-Currently supports ChatGPT (OpenAI) subscriptions: ``arbor login openai`` runs a
-browser OAuth flow so Plus/Pro/Team subscribers can drive Arbor with their
-subscription instead of a pay-per-token API key.
+Supports ChatGPT (OpenAI) and Claude (Anthropic) subscriptions: ``arbor login
+openai`` / ``arbor login claude`` run a browser OAuth flow so subscribers can
+drive Arbor with their subscription instead of a pay-per-token API key.
 
-Heads-up: using a ChatGPT subscription token with third-party tooling may
-violate OpenAI's terms and can get the account rate-limited or banned. This is
+Heads-up: using a subscription token with third-party tooling may violate the
+provider's terms and can get the account rate-limited or banned. This is
 strictly opt-in.
 """
 
@@ -63,31 +63,105 @@ def login_openai(
     _console.print("Run [bold]arbor[/] to start a session.")
 
 
+@login_app.command("claude")
+def login_claude(
+    no_browser: bool = typer.Option(
+        False, "--no-browser",
+        help="Print the auth URL instead of opening a browser.",
+    ),
+    set_default: bool = typer.Option(
+        True, "--set-default/--no-set-default",
+        help="Write provider=anthropic-oauth to the global config after login.",
+    ),
+) -> None:
+    """Log in to Claude and store the subscription token under ~/.arbor/oauth/."""
+    from ...core.oauth import anthropic as oauth
+    from ..style import console as _console
+
+    _console.print(
+        "[yellow]Experimental:[/] using a Claude subscription token with "
+        "third-party tools may violate Anthropic's terms and risks your account."
+    )
+    try:
+        tokens = oauth.login(open_browser=not no_browser)
+    except oauth.OAuthError as exc:
+        _console.print(f"[red]login failed:[/] {exc}")
+        raise typer.Exit(code=1)
+
+    who = tokens.account_email or "(account unavailable)"
+    _console.print(f"[green]✓[/] signed in to Claude — account=[bold]{who}[/]")
+
+    if set_default:
+        from .._constants import DEFAULT_CLAUDE_OAUTH_MODEL
+
+        model = DEFAULT_CLAUDE_OAUTH_MODEL
+        write_user_llm_config({"provider": "anthropic-oauth", "model": model})
+        _console.print(
+            f"[green]✓[/] set provider=anthropic-oauth (model={model}) in {GLOBAL_CONFIG_FILE}"
+        )
+    _console.print("Run [bold]arbor[/] to start a session.")
+
+
 @login_app.command("status")
 def login_status() -> None:
-    """Show the current ChatGPT login state."""
+    """Show the current subscription login state for each provider."""
+    from ...core.oauth import anthropic as claude_oauth
     from ...core.oauth import openai as oauth
     from ..style import console as _console
 
+    any_signed_in = False
+
     tokens = oauth.load_tokens()
-    if tokens is None:
-        _console.print("[yellow]not signed in[/] — run `arbor login openai`")
+    if tokens is not None:
+        any_signed_in = True
+        plan = tokens.plan_type or "unknown"
+        state = "expired (will refresh)" if tokens.is_expired else "valid"
+        _console.print(
+            f"[green]signed in[/] to ChatGPT — plan=[bold]{plan}[/], "
+            f"account={tokens.account_id or 'unknown'}, access token {state}"
+        )
+
+    ctokens = claude_oauth.load_tokens()
+    if ctokens is not None:
+        any_signed_in = True
+        state = "expired (will refresh)" if ctokens.is_expired else "valid"
+        _console.print(
+            f"[green]signed in[/] to Claude — "
+            f"account={ctokens.account_email or 'unknown'}, access token {state}"
+        )
+
+    if not any_signed_in:
+        _console.print(
+            "[yellow]not signed in[/] — run `arbor login openai` or `arbor login claude`"
+        )
         raise typer.Exit(code=1)
-    plan = tokens.plan_type or "unknown"
-    state = "expired (will refresh)" if tokens.is_expired else "valid"
-    _console.print(
-        f"[green]signed in[/] to ChatGPT — plan=[bold]{plan}[/], "
-        f"account={tokens.account_id or 'unknown'}, access token {state}"
-    )
 
 
 @login_app.command("logout")
-def login_logout() -> None:
-    """Delete the stored ChatGPT subscription token."""
+def login_logout(
+    provider: str = typer.Argument(
+        "all",
+        help="Which token to remove: openai | claude | all (default).",
+    ),
+) -> None:
+    """Delete the stored subscription token(s)."""
+    from ...core.oauth import anthropic as claude_oauth
     from ...core.oauth import openai as oauth
     from ..style import console as _console
 
-    if oauth.clear_tokens():
-        _console.print("[green]✓[/] removed stored ChatGPT token")
-    else:
+    target = provider.strip().lower()
+    if target not in ("all", "openai", "chatgpt", "claude", "anthropic"):
+        _console.print("[red]unknown provider[/] — use openai, claude, or all")
+        raise typer.Exit(code=1)
+
+    removed = False
+    if target in ("all", "openai", "chatgpt"):
+        if oauth.clear_tokens():
+            _console.print("[green]✓[/] removed stored ChatGPT token")
+            removed = True
+    if target in ("all", "claude", "anthropic"):
+        if claude_oauth.clear_tokens():
+            _console.print("[green]✓[/] removed stored Claude token")
+            removed = True
+    if not removed:
         _console.print("[dim]nothing to remove (not signed in)[/]")

--- a/src/cli/commands/setup_cmd.py
+++ b/src/cli/commands/setup_cmd.py
@@ -50,12 +50,16 @@ def run_setup_wizard(*, force: bool = False) -> bool:
             ("openai-chat", "any OpenAI-compatible endpoint (DeepSeek / Qwen / GLM / …)"),
             ("openai-oauth", "ChatGPT Plus/Pro subscription via browser login (experimental)"),
             ("anthropic", "Claude via the native Anthropic API"),
+            ("anthropic-oauth", "Claude Pro/Max subscription via browser login (experimental)"),
         ],
         default="auto",
     )
 
     if provider == "openai-oauth":
         return _setup_openai_oauth()
+
+    if provider == "anthropic-oauth":
+        return _setup_anthropic_oauth()
 
     # 2. base_url (local proxy / vLLM / official API)
     base_url = typer.prompt(
@@ -122,6 +126,39 @@ def _setup_openai_oauth() -> bool:
     _console.print()
     write_user_llm_config(
         {"provider": "openai-oauth", "model": model, "reasoning_effort": effort}
+    )
+    _console.print(
+        f"\n[green]Done.[/] Saved to [bold]{GLOBAL_CONFIG_FILE}[/]. "
+        "Just run [bold]arbor[/] to start a session.\n"
+    )
+    return True
+
+
+def _setup_anthropic_oauth() -> bool:
+    """Run the Claude subscription login, then write the global config."""
+    from ...core.oauth import anthropic as oauth
+    from .._constants import DEFAULT_CLAUDE_OAUTH_MODEL
+    from ..style import console as _console
+
+    _console.print()
+    _console.print(
+        "[yellow]Experimental:[/] using a Claude subscription token with "
+        "third-party tools may violate Anthropic's terms and risks your account."
+    )
+    try:
+        tokens = oauth.login()
+    except oauth.OAuthError as exc:
+        _console.print(f"[red]login failed:[/] {exc}")
+        return False
+
+    who = tokens.account_email or "signed in"
+    _console.print(f"[green]✓[/] signed in to Claude — [bold]{who}[/]")
+
+    model = typer.prompt("Model", default=DEFAULT_CLAUDE_OAUTH_MODEL).strip() or DEFAULT_CLAUDE_OAUTH_MODEL
+    effort = _prompt_reasoning_effort()
+    _console.print()
+    write_user_llm_config(
+        {"provider": "anthropic-oauth", "model": model, "reasoning_effort": effort}
     )
     _console.print(
         f"\n[green]Done.[/] Saved to [bold]{GLOBAL_CONFIG_FILE}[/]. "

--- a/src/cli/preflight.py
+++ b/src/cli/preflight.py
@@ -120,6 +120,9 @@ class PreflightChecker:
         if self.provider == "openai-oauth":
             return self._check_openai_oauth()
 
+        if self.provider == "anthropic-oauth":
+            return self._check_anthropic_oauth()
+
         if self.provider not in self._PROVIDER_ENV:
             return CheckResult(
                 "llm", "fail",
@@ -178,6 +181,27 @@ class PreflightChecker:
         plan = tokens.plan_type or "unknown"
         return CheckResult("llm", "pass",
                            f"ChatGPT subscription token found (plan={plan})")
+
+    @staticmethod
+    def _check_anthropic_oauth() -> CheckResult:
+        """Claude subscription auth lives in a token file, not an env var."""
+        try:
+            from ..core.oauth import anthropic as oauth
+        except ImportError:
+            return CheckResult(
+                "llm", "fail", "claude oauth support unavailable",
+                hint="reinstall arbor",
+            )
+        tokens = oauth.load_tokens()
+        if tokens is None:
+            return CheckResult(
+                "llm", "fail",
+                "not logged in to Claude (provider=anthropic-oauth)",
+                hint="run `arbor login claude`",
+            )
+        who = tokens.account_email or "account"
+        return CheckResult("llm", "pass",
+                           f"Claude subscription token found ({who})")
 
     # ── Check 2: codebase ──────────────────────────────────────────
 

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -32,15 +32,17 @@ __all__ = [
 def resolve_backend(provider: str | None, openai_api: str | None, model: str | None, base_url: str | None) -> str:
     """Collapse the (provider, openai_api) config onto one backend id.
 
-    Returns one of: ``anthropic`` | ``openai-oauth`` | ``openai-responses`` |
-    ``openai-chat`` | ``litellm``. ``provider="auto"`` (the default) routes by
-    model name:
+    Returns one of: ``anthropic`` | ``anthropic-oauth`` | ``openai-oauth`` |
+    ``openai-responses`` | ``openai-chat`` | ``litellm``. ``provider="auto"``
+    (the default) routes by model name:
     a ``claude*`` model on the default endpoint uses the native Anthropic
     backend (prompt caching); everything else uses litellm.
     """
     p = (provider or "auto").lower()
     if p in ("claude", "anthropic"):
         return "anthropic"
+    if p in ("anthropic-oauth", "claude-oauth", "claude-pro", "anthropic_oauth"):
+        return "anthropic-oauth"
     if p in ("openai-oauth", "chatgpt", "openai_oauth"):
         return "openai-oauth"
     if p in ("openai-responses", "responses"):
@@ -72,6 +74,15 @@ def create_provider(config: AgentConfig) -> LLMProvider:
             model=config.model,
             api_key=config.api_key,
             base_url=config.base_url,
+            max_retries=config.llm_provider_retries,
+            timeout=config.llm_timeout,
+            reasoning_effort=config.reasoning_effort,
+            thinking_budget_tokens=config.thinking_budget_tokens,
+        )
+    if backend == "anthropic-oauth":
+        from .llm.claude_oauth import ClaudeOAuthProvider
+        return ClaudeOAuthProvider(
+            model=config.model,
             max_retries=config.llm_provider_retries,
             timeout=config.llm_timeout,
             reasoning_effort=config.reasoning_effort,

--- a/src/core/config_cli.py
+++ b/src/core/config_cli.py
@@ -44,7 +44,7 @@ class CLIField:
 # the groups they expose, so a shared field (e.g. --provider) is declared once.
 
 LLM_FLAGS: tuple[CLIField, ...] = (
-    CLIField("--provider", "provider", str, "Backend: auto (default) | anthropic | openai-responses | openai-chat | openai-oauth | litellm", choices=("auto", "anthropic", "claude", "openai", "openai-responses", "openai-chat", "openai-oauth", "litellm")),
+    CLIField("--provider", "provider", str, "Backend: auto (default) | anthropic | anthropic-oauth | openai-responses | openai-chat | openai-oauth | litellm", choices=("auto", "anthropic", "anthropic-oauth", "claude", "claude-oauth", "openai", "openai-responses", "openai-chat", "openai-oauth", "litellm")),
     CLIField("--model", "model", str, "Model name (default: claude-sonnet-4-20250514 / gpt-4o)"),
     CLIField("--api-key", "api_key", str, "API key (default: from env)"),
     CLIField("--base-url", "base_url", str, "Custom API base URL (vLLM, Ollama, proxy, ...)"),

--- a/src/core/llm/claude_oauth.py
+++ b/src/core/llm/claude_oauth.py
@@ -1,0 +1,116 @@
+"""Claude-subscription Messages provider (experimental).
+
+Authenticates with an OAuth access token obtained via ``arbor login claude`` and
+talks to the Anthropic Messages API as a ``Bearer`` token (with the
+``anthropic-beta: oauth-2025-04-20`` header) instead of a pay-per-token
+``ANTHROPIC_API_KEY``. Everything else — message conversion, thinking replay,
+tool calls, prompt caching, parsing — is inherited from
+:class:`ClaudeProvider`.
+
+The subscription backend only accepts requests that identify as Claude Code, so
+the Claude Code system prompt is prepended to every call. Tokens are refreshed
+transparently before each call. Using a Claude subscription token with
+third-party tooling may violate Anthropic's terms; this backend is strictly
+opt-in.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+import anthropic
+
+from ..oauth import anthropic as oauth
+from .base import LLMResponse, StreamEvent
+from .claude import ClaudeProvider
+
+
+class ClaudeOAuthProvider(ClaudeProvider):
+    """Messages provider backed by a Claude subscription OAuth token."""
+
+    def __init__(
+        self,
+        model: str = "claude-sonnet-4-5-20250929",
+        *,
+        max_retries: int = 3,
+        timeout: float = 300.0,
+        reasoning_effort: str | None = "high",
+        thinking_budget_tokens: int | None = None,
+        **_ignored: Any,
+    ) -> None:
+        tokens = oauth.get_valid_tokens()
+        self._max_retries = max_retries
+        self._access_token = tokens.access_token
+        # Build the base provider with a placeholder key (we never use it) so we
+        # inherit the tokenizer/config setup, then swap in an OAuth client.
+        super().__init__(
+            model=model,
+            api_key="oauth-placeholder",
+            base_url=None,
+            max_retries=max_retries,
+            timeout=timeout,
+            reasoning_effort=reasoning_effort,
+            thinking_budget_tokens=thinking_budget_tokens,
+        )
+        self._rebuild_client(tokens.access_token)
+
+    def _rebuild_client(self, access_token: str) -> None:
+        # ``auth_token`` makes the SDK send ``Authorization: Bearer <token>``
+        # (and skip ``x-api-key``); the beta header opts into the OAuth backend.
+        self._client = anthropic.AsyncAnthropic(
+            auth_token=access_token,
+            max_retries=self._max_retries,
+            timeout=self.timeout,
+            default_headers={"anthropic-beta": oauth.OAUTH_BETA},
+        )
+
+    async def _ensure_fresh(self) -> None:
+        """Refresh the token if it is near expiry, rebuilding the client once."""
+        tokens = await asyncio.to_thread(oauth.get_valid_tokens)
+        if tokens.access_token != self._access_token:
+            self._access_token = tokens.access_token
+            self._rebuild_client(tokens.access_token)
+
+    def _build_params(
+        self,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        max_tokens: int,
+    ) -> dict[str, Any]:
+        params = super()._build_params(system, messages, tools, max_tokens)
+        # The subscription backend rejects requests whose first system block is
+        # not the Claude Code identity, so prepend it ahead of the real prompt.
+        params["system"] = [
+            {"type": "text", "text": oauth.CLAUDE_CODE_SYSTEM_PROMPT},
+            *params["system"],
+        ]
+        return params
+
+    async def create(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 16384,
+    ) -> LLMResponse:
+        await self._ensure_fresh()
+        return await super().create(
+            system=system, messages=messages, tools=tools, max_tokens=max_tokens
+        )
+
+    async def create_streaming(
+        self,
+        *,
+        system: str,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        max_tokens: int = 16384,
+    ) -> AsyncIterator[StreamEvent]:
+        await self._ensure_fresh()
+        async for event in super().create_streaming(
+            system=system, messages=messages, tools=tools, max_tokens=max_tokens
+        ):
+            yield event

--- a/src/core/oauth/anthropic.py
+++ b/src/core/oauth/anthropic.py
@@ -1,0 +1,249 @@
+"""Claude (Anthropic) subscription OAuth — login, token storage, refresh.
+
+EXPERIMENTAL / UNSUPPORTED. Replicates the Claude Code OAuth (PKCE) flow so that
+Claude Pro/Max subscribers can drive Arbor with their subscription instead of a
+pay-per-token ``ANTHROPIC_API_KEY``. The obtained access token is sent to the
+Anthropic Messages API as a ``Bearer`` token (with the ``anthropic-beta:
+oauth-2025-04-20`` header) by
+:class:`arbor.core.llm.claude_oauth.ClaudeOAuthProvider`.
+
+Tokens live in ``~/.arbor/oauth/anthropic.json`` (chmod 600). Using a Claude
+subscription token with third-party tooling may violate Anthropic's terms and
+can get the account rate-limited or banned; this path is strictly opt-in.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import time
+import urllib.parse
+import webbrowser
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+
+import httpx
+
+from ..._app import GLOBAL_CONFIG_DIR
+
+# ── Public constants (Claude Code public OAuth client) ───────────────────────
+CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+AUTHORIZE_URL = "https://claude.ai/oauth/authorize"
+TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
+SCOPES = "org:create_api_key user:profile user:inference"
+
+# Beta header the subscription backend requires for OAuth (Bearer) requests.
+OAUTH_BETA = "oauth-2025-04-20"
+# The subscription backend only accepts requests that identify as Claude Code;
+# this string must be the first system block on every Messages call.
+CLAUDE_CODE_SYSTEM_PROMPT = "You are Claude Code, Anthropic's official CLI for Claude."
+
+TOKEN_PATH = GLOBAL_CONFIG_DIR / "oauth" / "anthropic.json"
+
+# Refresh proactively this many seconds before the access token expires.
+_REFRESH_SKEW = 300
+# Default access-token lifetime when the issuer omits ``expires_in``.
+_DEFAULT_EXPIRES_IN = 3600
+
+
+class OAuthError(RuntimeError):
+    """Raised for any failure in the login / refresh flow."""
+
+
+@dataclass
+class AnthropicTokens:
+    access_token: str
+    refresh_token: str
+    scope: str = ""
+    account_email: str = ""
+    expires_at: float = 0.0
+
+    @property
+    def is_expired(self) -> bool:
+        return time.time() >= (self.expires_at - _REFRESH_SKEW)
+
+
+# ── Low-level encoding helpers ───────────────────────────────────────────────
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = _b64url(secrets.token_bytes(64))
+    challenge = _b64url(hashlib.sha256(verifier.encode("ascii")).digest())
+    return verifier, challenge
+
+
+# ── Token persistence ────────────────────────────────────────────────────────
+
+def load_tokens() -> AnthropicTokens | None:
+    """Return stored tokens, or ``None`` if the user has not logged in."""
+    if not TOKEN_PATH.exists():
+        return None
+    try:
+        data = json.loads(TOKEN_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not data.get("access_token") or not data.get("refresh_token"):
+        return None
+    known = {f for f in AnthropicTokens.__dataclass_fields__}
+    return AnthropicTokens(**{k: v for k, v in data.items() if k in known})
+
+
+def save_tokens(tokens: AnthropicTokens) -> None:
+    TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    TOKEN_PATH.write_text(json.dumps(asdict(tokens), indent=2), encoding="utf-8")
+    try:
+        os.chmod(TOKEN_PATH, 0o600)
+    except OSError:
+        pass
+
+
+def clear_tokens() -> bool:
+    """Delete stored tokens. Returns True if a file was removed."""
+    if TOKEN_PATH.exists():
+        TOKEN_PATH.unlink()
+        return True
+    return False
+
+
+# ── HTTP token exchange / refresh ────────────────────────────────────────────
+
+def _post_token(body: dict[str, str]) -> dict[str, Any]:
+    """POST a JSON body to the token endpoint (Anthropic expects JSON, not form)."""
+    try:
+        resp = httpx.post(
+            TOKEN_URL,
+            json=body,
+            headers={"Content-Type": "application/json"},
+            timeout=30.0,
+        )
+    except httpx.HTTPError as exc:  # pragma: no cover - network failure
+        raise OAuthError(f"token endpoint request failed: {exc}") from exc
+    if resp.status_code != 200:
+        raise OAuthError(
+            f"token endpoint returned {resp.status_code}: {resp.text[:300]}"
+        )
+    return resp.json()
+
+
+def _tokens_from_response(
+    data: dict[str, Any], *, fallback_refresh: str = "", fallback_email: str = ""
+) -> AnthropicTokens:
+    access_token = data.get("access_token") or ""
+    if not access_token:
+        raise OAuthError("token response missing access_token")
+    refresh_token = data.get("refresh_token") or fallback_refresh
+    account = data.get("account")
+    email = ""
+    if isinstance(account, dict):
+        email = str(account.get("email_address") or account.get("email") or "")
+    expires_in = int(data.get("expires_in") or _DEFAULT_EXPIRES_IN)
+    return AnthropicTokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        scope=str(data.get("scope") or ""),
+        account_email=email or fallback_email,
+        expires_at=time.time() + expires_in,
+    )
+
+
+def refresh(tokens: AnthropicTokens) -> AnthropicTokens:
+    """Exchange the refresh token for a fresh access token and persist it."""
+    if not tokens.refresh_token:
+        raise OAuthError("no refresh token available; run `arbor login claude` again")
+    data = _post_token({
+        "grant_type": "refresh_token",
+        "client_id": CLIENT_ID,
+        "refresh_token": tokens.refresh_token,
+    })
+    refreshed = _tokens_from_response(
+        data,
+        fallback_refresh=tokens.refresh_token,
+        fallback_email=tokens.account_email,
+    )
+    save_tokens(refreshed)
+    return refreshed
+
+
+def get_valid_tokens() -> AnthropicTokens:
+    """Load tokens, refreshing if they are expired. Raises if not logged in."""
+    tokens = load_tokens()
+    if tokens is None:
+        raise OAuthError("not logged in to Claude — run `arbor login claude`")
+    if tokens.is_expired:
+        tokens = refresh(tokens)
+    return tokens
+
+
+# ── Browser login flow (manual code paste) ───────────────────────────────────
+
+def _authorize_url(challenge: str, state: str) -> str:
+    query = urllib.parse.urlencode({
+        "code": "true",
+        "client_id": CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": REDIRECT_URI,
+        "scope": SCOPES,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "state": state,
+    })
+    return f"{AUTHORIZE_URL}?{query}"
+
+
+def _split_code(raw: str, *, expected_state: str) -> tuple[str, str]:
+    """Split the pasted ``code#state`` value into ``(code, state)``.
+
+    Anthropic's callback page shows ``<code>#<state>``; some users paste only
+    the code, in which case we assume the state we sent round-trips unchanged.
+    """
+    code, sep, state = raw.partition("#")
+    return code.strip(), (state.strip() if sep else expected_state)
+
+
+def login(
+    *, open_browser: bool = True, code_input: Callable[[], str] | None = None
+) -> AnthropicTokens:
+    """Run the interactive browser OAuth flow and persist the tokens.
+
+    Opens the Claude authorization URL, asks the user to paste the
+    ``code#state`` value the callback page displays, exchanges it (PKCE), and
+    saves the resulting tokens. Returns the stored :class:`AnthropicTokens`.
+    """
+    verifier, challenge = _pkce()
+    state = _b64url(secrets.token_bytes(32))
+    url = _authorize_url(challenge, state)
+
+    opened = webbrowser.open(url) if open_browser else False
+    print("\nOpen this URL to authorize Arbor with your Claude account:")
+    print(f"\n  {url}\n")
+    if not opened:
+        print("(Could not auto-open a browser; paste the URL above.)\n")
+    print("After approving, copy the code shown on the page and paste it here.")
+
+    raw = (code_input() if code_input is not None else input("\nAuthorization code: ")).strip()
+    if not raw:
+        raise OAuthError("no authorization code provided")
+    code, returned_state = _split_code(raw, expected_state=state)
+    if returned_state != state:
+        raise OAuthError("OAuth state mismatch — aborting (possible CSRF)")
+    if not code:
+        raise OAuthError("no authorization code provided")
+
+    data = _post_token({
+        "grant_type": "authorization_code",
+        "client_id": CLIENT_ID,
+        "code": code,
+        "state": returned_state,
+        "redirect_uri": REDIRECT_URI,
+        "code_verifier": verifier,
+    })
+    tokens = _tokens_from_response(data)
+    save_tokens(tokens)
+    return tokens

--- a/tests/test_anthropic_oauth.py
+++ b/tests/test_anthropic_oauth.py
@@ -1,0 +1,162 @@
+"""Tests for the experimental Claude subscription OAuth backend."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from arbor.core import resolve_backend
+from arbor.core.oauth import anthropic as oauth
+from arbor.cli._constants import canonical_provider, default_model_for_provider
+
+
+# ── Routing ──────────────────────────────────────────────────────────────────
+
+def test_resolve_backend_recognizes_oauth():
+    assert resolve_backend("anthropic-oauth", None, "claude-sonnet-4", None) == "anthropic-oauth"
+    assert resolve_backend("claude-oauth", None, "claude-sonnet-4", None) == "anthropic-oauth"
+    assert resolve_backend("claude-pro", None, "claude-sonnet-4", None) == "anthropic-oauth"
+
+
+def test_canonical_and_default_model():
+    assert canonical_provider("anthropic-oauth") == "anthropic-oauth"
+    assert canonical_provider("claude-oauth") == "anthropic-oauth"
+    from arbor.cli._constants import DEFAULT_CLAUDE_OAUTH_MODEL
+    assert default_model_for_provider("anthropic-oauth") == DEFAULT_CLAUDE_OAUTH_MODEL
+
+
+# ── Authorize URL / code parsing ─────────────────────────────────────────────
+
+def test_authorize_url_has_pkce_and_state():
+    url = oauth._authorize_url("chal", "st8")
+    assert url.startswith(oauth.AUTHORIZE_URL)
+    assert "code_challenge=chal" in url
+    assert "code_challenge_method=S256" in url
+    assert "state=st8" in url
+    assert "code=true" in url
+
+
+def test_split_code_with_state():
+    code, state = oauth._split_code("abc#xyz", expected_state="fallback")
+    assert code == "abc"
+    assert state == "xyz"
+
+
+def test_split_code_without_state_uses_expected():
+    code, state = oauth._split_code("abc", expected_state="fallback")
+    assert code == "abc"
+    assert state == "fallback"
+
+
+# ── Token persistence ────────────────────────────────────────────────────────
+
+def test_save_load_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "oauth" / "anthropic.json")
+    tokens = oauth.AnthropicTokens(
+        access_token="at", refresh_token="rt", account_email="user@example.com",
+        scope="user:inference", expires_at=time.time() + 3600,
+    )
+    oauth.save_tokens(tokens)
+    loaded = oauth.load_tokens()
+    assert loaded is not None
+    assert loaded.access_token == "at"
+    assert loaded.account_email == "user@example.com"
+    assert not loaded.is_expired
+    assert oauth.clear_tokens() is True
+    assert oauth.load_tokens() is None
+
+
+def test_load_missing_returns_none(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "nope.json")
+    assert oauth.load_tokens() is None
+
+
+# ── Token response parsing ───────────────────────────────────────────────────
+
+def test_tokens_from_response_extracts_email():
+    data = {
+        "access_token": "at", "refresh_token": "rt", "expires_in": 3600,
+        "scope": "user:inference",
+        "account": {"email_address": "u@example.com", "uuid": "abc"},
+    }
+    tokens = oauth._tokens_from_response(data)
+    assert tokens.access_token == "at"
+    assert tokens.account_email == "u@example.com"
+    assert tokens.scope == "user:inference"
+    assert not tokens.is_expired
+
+
+def test_tokens_from_response_requires_access_token():
+    with pytest.raises(oauth.OAuthError):
+        oauth._tokens_from_response({"refresh_token": "rt"})
+
+
+# ── Refresh ──────────────────────────────────────────────────────────────────
+
+def test_refresh_preserves_email_and_refresh_token(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "anthropic.json")
+    monkeypatch.setattr(oauth, "_post_token", lambda body: {
+        "access_token": "new-at", "expires_in": 3600,
+        # refresh response omits refresh_token and account
+    })
+    old = oauth.AnthropicTokens(
+        access_token="old", refresh_token="rt", account_email="keep@example.com",
+        expires_at=0,
+    )
+    refreshed = oauth.refresh(old)
+    assert refreshed.access_token == "new-at"
+    assert refreshed.refresh_token == "rt"               # fell back to the old one
+    assert refreshed.account_email == "keep@example.com"  # preserved across refresh
+
+
+def test_get_valid_tokens_refreshes_when_expired(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "anthropic.json")
+    expired = oauth.AnthropicTokens(
+        access_token="old", refresh_token="rt", expires_at=0,
+    )
+    oauth.save_tokens(expired)
+    monkeypatch.setattr(oauth, "_post_token", lambda body: {
+        "access_token": "fresh", "refresh_token": "rt2", "expires_in": 3600,
+    })
+    tokens = oauth.get_valid_tokens()
+    assert tokens.access_token == "fresh"
+
+
+def test_get_valid_tokens_raises_when_logged_out(tmp_path, monkeypatch):
+    monkeypatch.setattr(oauth, "TOKEN_PATH", tmp_path / "anthropic.json")
+    with pytest.raises(oauth.OAuthError):
+        oauth.get_valid_tokens()
+
+
+# ── Provider wiring ──────────────────────────────────────────────────────────
+
+def test_provider_builds_oauth_client(monkeypatch):
+    from arbor.core.llm.claude_oauth import ClaudeOAuthProvider
+
+    fake = oauth.AnthropicTokens(
+        access_token="tok", refresh_token="rt", account_email="u@example.com",
+        expires_at=time.time() + 3600,
+    )
+    monkeypatch.setattr(oauth, "get_valid_tokens", lambda: fake)
+
+    provider = ClaudeOAuthProvider(model="claude-sonnet-4-20250514")
+    assert provider._access_token == "tok"
+    # The OAuth beta header must be present on the client.
+    headers = provider._client.default_headers
+    assert headers.get("anthropic-beta") == oauth.OAUTH_BETA
+
+
+def test_build_params_prepends_claude_code_identity(monkeypatch):
+    from arbor.core.llm.claude_oauth import ClaudeOAuthProvider
+
+    fake = oauth.AnthropicTokens(
+        access_token="tok", refresh_token="rt", expires_at=time.time() + 3600,
+    )
+    monkeypatch.setattr(oauth, "get_valid_tokens", lambda: fake)
+
+    provider = ClaudeOAuthProvider(model="claude-sonnet-4-20250514")
+    params = provider._build_params("real system prompt", [], None, 16384)
+    system = params["system"]
+    assert system[0]["text"] == oauth.CLAUDE_CODE_SYSTEM_PROMPT
+    assert system[1]["text"] == "real system prompt"


### PR DESCRIPTION
## Summary / 概述
Adds an **experimental, opt-in** Claude (Anthropic) subscription OAuth backend so Claude Pro/Max subscribers can drive Arbor with their subscription instead of a pay-per-token `ANTHROPIC_API_KEY`. Mirrors the existing ChatGPT `openai-oauth` flow one-to-one.

> ⚠️ **Experimental / unsupported.** Using a Claude subscription token with third-party tooling may violate Anthropic's terms and can get the account rate-limited or banned. Strictly opt-in.

## What's included / 改动内容

- **OAuth (PKCE) login flow** — `arbor login claude` / `status` / `logout`. Browser authorize + manual `code#state` paste (Anthropic redirects to `console.anthropic.com/oauth/code/callback`, not localhost). Tokens stored at `~/.arbor/oauth/anthropic.json` (chmod 600), proactive refresh with skew. `status`/`logout` now cover both OpenAI and Claude.
- **`ClaudeOAuthProvider`** — subclasses `ClaudeProvider`; sends the token as `Authorization: Bearer` via the SDK's `auth_token` plus the `anthropic-beta: oauth-2025-04-20` header, prepends the required Claude Code system block, and refreshes the token before each call. Inherits message/tool/thinking/prompt-caching handling unchanged.
- **Provider routing** — `provider: anthropic-oauth` (aliases `claude-oauth` / `claude-pro`) wired through `resolve_backend` / `create_provider`.
- **Setup wizard** — Claude OAuth option on the API-type selector with its own login + reasoning-effort path; preflight credential check (`_check_anthropic_oauth`) and config-CLI `--provider` choices updated.
- **Default OAuth model** `claude-sonnet-4-5-20250929` — the subscription backend only serves current snapshots (the dated API-key default 404s there).
- Docs (`configuration.md`) and tests.

## How tested / 验证

- `pytest` — full suite green (161 passed), incl. new `tests/test_anthropic_oauth.py` (routing/aliases, authorize-URL + PKCE, `code#state` parsing, token persistence, refresh-preserves-email/refresh-token, provider client headers, Claude Code system-block injection).
- **Live end-to-end**: real `arbor login claude` browser flow succeeded; a Messages call through the OAuth token returned the expected output. The original model 404 confirmed auth works (a bad token returns 401/403) and surfaced the snapshot-availability constraint.
- Routing regression check — all pre-existing providers (`anthropic`, `openai-*`, `litellm`, `auto`) resolve unchanged.

## Notes / 已知点

- **Token-file concurrency**: parallel executors each refresh and write the same token file without a lock; concurrent refreshes could race if the issuer rotates refresh tokens. Acceptable for the experimental path; a file-lock/single-flight is a sensible follow-up (same caveat as `openai-oauth`).
- **Login is manual-paste**, not a localhost callback, because Anthropic's subscription OAuth only allows the `console.anthropic.com` redirect.
- Subscription backend serves only current model snapshots — if a model 404s, pick a live one from `client.models.list()`.

## Type / 类型

- ✨ Feature (`feat`) — experimental