### PR TITLE
Harden MCP tool path boundaries + web monitor headers

### DIFF
--- a/src/mcp/session_ops.py
+++ b/src/mcp/session_ops.py
@@ -66,9 +66,22 @@ _SCORE_PATTERNS = [
 # ── Session path helpers ──────────────────────────────────────────────────────
 
 
+def _safe_run_name(run_name: str) -> str:
+    """Reduce a tool-supplied ``run_name`` to a single safe path component.
+
+    The MCP tools take ``run_name`` from the host agent, so a value like
+    ``../../etc`` or ``/abs/path`` must not let the session path escape
+    ``<cwd>/.arbor/sessions/``. We map anything outside ``[A-Za-z0-9_.-]`` to
+    ``-`` (this also neutralises ``/`` and ``\\``, so an absolute path can't reset
+    the join) and strip leading dots so the result can never be ``.`` or ``..``.
+    """
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", str(run_name)).lstrip(".")
+    return safe or "session"
+
+
 def session_dir(cwd: str | Path, run_name: str) -> Path:
     """Return ``<cwd>/.arbor/sessions/<run_name>`` (the per-run session root)."""
-    return Path(cwd).resolve() / ".arbor" / "sessions" / run_name
+    return Path(cwd).resolve() / ".arbor" / "sessions" / _safe_run_name(run_name)
 
 
 def coordinator_dir(cwd: str | Path, run_name: str) -> Path:
@@ -467,11 +480,21 @@ def worktree_create(
 
 
 def worktree_remove(cwd: str | Path, worktree: str | Path) -> dict[str, Any]:
-    """Force-remove a previously created experiment worktree."""
-    rc, out = git(cwd, "worktree", "remove", "--force", str(worktree))
+    """Force-remove a previously created experiment worktree.
+
+    The path comes from a tool call, so we refuse to ``rmtree`` anything that is
+    not strictly inside our per-user worktree scratch root — a purpose-specific
+    tool should never expose unbounded deletion, even though the host agent is
+    otherwise trusted.
+    """
+    wt = Path(worktree).resolve()
+    base = _worktree_base("worktrees").resolve()
+    if base not in wt.parents:
+        raise ValueError(f"refusing to remove a worktree outside {base}: {wt}")
+    rc, out = git(cwd, "worktree", "remove", "--force", str(wt))
     # Clear any leftover directory git did not remove (e.g. an orphaned path).
-    shutil.rmtree(Path(worktree), ignore_errors=True)
-    return {"removed": str(worktree), "returncode": rc, "output": out}
+    shutil.rmtree(wt, ignore_errors=True)
+    return {"removed": str(wt), "returncode": rc, "output": out}
 
 
 # ── Guarded merge ─────────────────────────────────────────────────────────────

--- a/src/webui/server.py
+++ b/src/webui/server.py
@@ -252,6 +252,9 @@ class _Handler(BaseHTTPRequestHandler):
             length = int(self.headers.get("Content-Length") or 0)
         except ValueError:
             length = 0
+        # Cap the body: a localhost client should never need more than a small
+        # JSON control message, and an unbounded Content-Length could OOM us.
+        length = min(length, 64 * 1024)
         raw = self.rfile.read(length) if length > 0 else b""
         try:
             msg = json.loads(raw or b"{}")
@@ -276,6 +279,9 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
+        # Harden the one HTML response: no MIME sniffing, no framing (clickjacking).
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("X-Frame-Options", "DENY")
         self.end_headers()
         self.wfile.write(body)
 
@@ -301,8 +307,9 @@ class _Handler(BaseHTTPRequestHandler):
         self.send_header("Content-Type", "text/event-stream")
         self.send_header("Cache-Control", "no-cache")
         self.send_header("Connection", "keep-alive")
-        # Safe: the server only binds 127.0.0.1 and is strictly read-only.
-        self.send_header("Access-Control-Allow-Origin", "*")
+        # No CORS header: the browser page is served from this same origin, so its
+        # EventSource doesn't need one — and dropping the previous wildcard stops
+        # any other local page from reading the session stream cross-origin.
         self.end_headers()
         q = webui.broadcast.register()
         try:

--- a/tests/test_mcp_session_ops.py
+++ b/tests/test_mcp_session_ops.py
@@ -278,3 +278,28 @@ def test_worktree_create_recovers_when_branch_already_exists(tmp_path: Path) -> 
     assert second["branch"] != "exp/dup"  # recovered under a unique suffix
     assert Path(second["worktree"]).is_dir()
     ops.worktree_remove(repo, second["worktree"])
+
+
+# ── path-boundary hardening (security review follow-up) ───────────────────────
+
+
+def test_session_dir_rejects_path_traversal(tmp_path: Path) -> None:
+    """A crafted run_name must never escape ``<cwd>/.arbor/sessions/``."""
+    sessions = (tmp_path / ".arbor" / "sessions").resolve()
+    for bad in ("../../etc", "/etc/passwd", "..", ".", "a/../../b", "....//"):
+        resolved = ops.session_dir(tmp_path, bad).resolve()
+        assert sessions in resolved.parents, f"{bad!r} escaped to {resolved}"
+    # A normal name is preserved verbatim.
+    assert ops.session_dir(tmp_path, "my-run_1.2").name == "my-run_1.2"
+
+
+def test_worktree_remove_refuses_paths_outside_scratch(tmp_path: Path) -> None:
+    """worktree_remove must not rmtree a path outside the worktree scratch root."""
+    victim = tmp_path / "precious"
+    victim.mkdir()
+    (victim / "keep.txt").write_text("do not delete", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="outside"):
+        ops.worktree_remove(tmp_path, victim)
+
+    assert victim.is_dir() and (victim / "keep.txt").exists()  # untouched


### PR DESCRIPTION
## Why

Follow-up to the security review of #19 (keyless multi-harness integration). That review found no critical/high issues, but flagged a few **defense-in-depth** items on the new MCP tool surface and the read-only web monitor. None are exploitable beyond the host agent's existing local access, but a purpose-specific tool shouldn't expose unbounded filesystem scope.

## Changes

**MCP session ops — `src/mcp/session_ops.py`** (were MEDIUM):
- `session_dir`: sanitize the tool-supplied `run_name` to a single safe path component, so `../../etc`, an absolute path, or `.`/`..` can't escape `<cwd>/.arbor/sessions/`. Normal names (`my-run_1.2`) pass through unchanged.
- `worktree_remove`: refuse to `shutil.rmtree` any path that isn't strictly inside the per-user worktree scratch root (`$TMPDIR/arbor-worktrees-<user>/`).

**Web monitor — `src/webui/server.py`** (were LOW):
- Cap the `POST /input` body to 64 KiB (a localhost control message is tiny; an unbounded `Content-Length` could OOM the process).
- Drop the wildcard `Access-Control-Allow-Origin: *` on the SSE stream — the page is served same-origin, so its `EventSource` never needed CORS, and the wildcard let any local page read the session stream cross-origin.
- Add `X-Content-Type-Options: nosniff` + `X-Frame-Options: DENY` to the HTML page.

## Tests

New cases in `tests/test_mcp_session_ops.py`:
- `run_name` traversal + absolute-path inputs all resolve under `.arbor/sessions/`.
- `worktree_remove` raises and does **not** delete a directory outside the scratch root.

Full suite green, ruff clean. Behavior for legitimate (in-scope) inputs is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)