### PR TITLE
feat(search): full-text/PDF reads (1.1d) + fix exa-mcp (keyless + text parsing)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,14 +239,15 @@ search:
     and the **novelty audit** (prior-art check *after* an experiment →
     `node.related_work`). `search.backends` is an ordered, merged list of
     sources; the keyless default is `[alphaxiv, jina]` (papers + general web,
-    no setup), with `serper` / `exa` / `exa-mcp` available behind their API
-    keys. Page reading is keyless too (`visit_backend: auto`, via the Jina
-    reader). See the **[Search & External Knowledge](search.md)** guide for the
-    full backend table, intents, keys, and examples.
+    no setup), with `serper` / `exa` available behind API keys and `exa-mcp`
+    keyless. Page reading is keyless too (`visit_backend: auto`, via the Jina
+    reader, with PDF support). See the **[Search & External Knowledge](search.md)**
+    guide for the full backend table, intents, keys, and examples.
 
     Key fields: `backends`, `grounded_ideation`, `auto_search_on_add`,
-    `visit_backend`, `serper_api_key` / `exa_api_key` / `jina_api_key`,
-    `exa_mcp_url`. Legacy `builtin_backend` / `web_search_endpoint` still work.
+    `visit_backend`, `visit_max_content_tokens` / `research_visit_tokens`,
+    `serper_api_key` / `exa_api_key` / `jina_api_key`, `exa_mcp_url`. Legacy
+    `builtin_backend` / `web_search_endpoint` still work.
 
 
 

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -204,11 +204,12 @@ search:
     Arbor 能在两条互相独立、默认关闭的 lane 中使用文献与开放网络——**接地 ideation**
     （ideation *期间*检索 → `node.grounding`）与**新颖性审查**（实验*之后*核查先行工作 →
     `node.related_work`）。`search.backends` 是一个有序、合并的来源列表；免 key 默认是
-    `[alphaxiv, jina]`（论文 + 通用网页，零配置），`serper` / `exa` / `exa-mcp` 在各自的
-    API key 后可用。读取页面同样免 key（`visit_backend: auto`，经 Jina reader）。完整后端表格、
+    `[alphaxiv, jina]`（论文 + 通用网页，零配置），`serper` / `exa` 需各自 API key、`exa-mcp`
+    免 key。读取页面同样免 key（`visit_backend: auto`，经 Jina reader，支持 PDF）。完整后端表格、
     intent、key 与示例见 **[检索与外部知识](search.zh.md)** 指南。
 
     关键字段：`backends`、`grounded_ideation`、`auto_search_on_add`、`visit_backend`、
+    `visit_max_content_tokens` / `research_visit_tokens`、
     `serper_api_key` / `exa_api_key` / `jina_api_key`、`exa_mcp_url`。旧的
     `builtin_backend` / `web_search_endpoint` 仍可用。
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -91,7 +91,7 @@ the same paper from two backends merges to one).
 | `jina` | no (optional `JINA_API_KEY` raises limits) | general web (s.jina.ai) |
 | `serper` | `SERPER_API_KEY` | Google results (serper.dev) |
 | `exa` | `EXA_API_KEY` | neural web search (exa.ai REST) |
-| `exa-mcp` | `EXA_API_KEY` | Exa via its hosted MCP server |
+| `exa-mcp` | no (optional `EXA_API_KEY` raises limits) | Exa via its hosted MCP server |
 | `endpoint` | optional | self-hosted `web_search_endpoint` (BrowseComp-style) |
 
 A backend whose key is missing is **silently skipped**, so a list like
@@ -104,11 +104,11 @@ or the matching env vars (`SERPER_API_KEY`, `EXA_API_KEY`, `JINA_API_KEY`).
 
 !!! note "Exa via MCP"
     The `exa-mcp` backend calls Exa's hosted MCP server
-    (`https://mcp.exa.ai/mcp`, auth via the `x-api-key` header; override the URL
-    with `exa_mcp_url`). It needs the optional MCP client:
+    (`https://mcp.exa.ai/mcp`; override the URL with `exa_mcp_url`). The hosted
+    server is **keyless** for basic use — set `exa_api_key` only to raise limits
+    (sent as the `x-api-key` header). It needs the MCP client:
     `pip install 'arbor-agent[mcp]'`. The plain `exa` backend hits the same
-    provider over its REST API and needs no extra dependency — pick whichever
-    fits your setup.
+    provider over its REST API (which *does* need a key) — pick whichever fits.
 
 ---
 
@@ -118,10 +118,19 @@ Reading a page is keyless too. `search.visit_backend: auto` (the default):
 
 - alphaXiv paper URLs → the alphaXiv SDK (full text), and
 - any other URL → the **Jina reader** (`r.jina.ai`, clean markdown, no key),
-  falling back to a raw `requests` fetch.
+  falling back to a raw `requests` fetch. **PDFs are read too** — the Jina
+  reader extracts PDF text, and the raw fallback parses PDFs via `pypdf`.
 
 So no browse endpoint or API key is needed to open a page. Force a single
 fetcher with `visit_backend: jina | requests | alphaxiv | endpoint`.
+
+**Reading depth (full text vs. abstract).** Page text is truncated to a token
+budget. The novelty-audit lane uses `visit_max_content_tokens` (default 2048 —
+abstracts are enough to judge prior art). The grounded-ideation lane reads for
+depth and uses the larger `research_visit_tokens` (default 6000) so a paper's
+**method / results sections survive truncation**, not just the abstract. Raise
+either for deeper reads (at higher token cost).
+
 
 ---
 

--- a/docs/search.zh.md
+++ b/docs/search.zh.md
@@ -79,7 +79,7 @@ arbor idea-check "一句话描述你的假设"
 | `jina` | 否（可选 `JINA_API_KEY` 提配额） | 通用网页（s.jina.ai） |
 | `serper` | `SERPER_API_KEY` | Google 结果（serper.dev） |
 | `exa` | `EXA_API_KEY` | 神经网络检索（exa.ai REST） |
-| `exa-mcp` | `EXA_API_KEY` | 经 Exa 托管 MCP 服务器接入 |
+| `exa-mcp` | 否（可选 `EXA_API_KEY` 提配额） | 经 Exa 托管 MCP 服务器接入 |
 | `endpoint` | 可选 | 自托管 `web_search_endpoint`（BrowseComp 风格） |
 
 缺少 key 的后端会被**静默跳过**——因此像 `[alphaxiv, jina, serper]` 这样的列表在没有 `SERPER_API_KEY`
@@ -89,9 +89,10 @@ key 写在配置文件里（`serper_api_key` / `exa_api_key` / `jina_api_key`）
 （`SERPER_API_KEY`、`EXA_API_KEY`、`JINA_API_KEY`）。
 
 !!! note "Exa via MCP"
-    `exa-mcp` 后端连接 Exa 托管的 MCP 服务器（`https://mcp.exa.ai/mcp`，用 `x-api-key` header 鉴权；
-    可用 `exa_mcp_url` 覆盖 URL）。它需要可选的 MCP 客户端：`pip install 'arbor-agent[mcp]'`。
-    而普通的 `exa` 后端走同一家的 REST API、无需额外依赖——按你的环境二选一即可。
+    `exa-mcp` 后端连接 Exa 托管的 MCP 服务器（`https://mcp.exa.ai/mcp`，可用 `exa_mcp_url` 覆盖 URL）。
+    托管服务器**免 key** 即可基本使用——设 `exa_api_key` 只是提配额（作为 `x-api-key` header 发送）。
+    它需要 MCP 客户端：`pip install 'arbor-agent[mcp]'`。而普通的 `exa` 后端走同一家的 REST API
+    （那个**需要** key）——按你的环境二选一。
 
 ---
 
@@ -101,9 +102,15 @@ key 写在配置文件里（`serper_api_key` / `exa_api_key` / `jina_api_key`）
 
 - alphaXiv 论文 URL → alphaXiv SDK（全文），
 - 其它任意 URL → **Jina reader**（`r.jina.ai`，干净 markdown，免 key），再 fallback 到原始 `requests` 抓取。
+  **PDF 也能读**——Jina reader 会抽取 PDF 文本，raw fallback 用 `pypdf` 解析 PDF。
 
 因此打开页面无需 browse 端点或 API key。也可强制单一取页器：
 `visit_backend: jina | requests | alphaxiv | endpoint`。
+
+**阅读深度（全文 vs 摘要）。** 页面文本会按 token 预算截断。新颖性审查 lane 用
+`visit_max_content_tokens`（默认 2048——判断先行工作有摘要就够）。接地 ideation lane 要读深度，
+用更大的 `research_visit_tokens`（默认 6000），让论文的**方法 / 结果章节不被截断**，而不只是摘要。
+需要更深可调大任一项（token 成本更高）。
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "httpx>=0.27.0",
     "requests>=2.28",
     "tiktoken>=0.7.0",
+    "pypdf>=4.0",
     "typer>=0.12.0",
     "rich>=13.0",
     "pyyaml>=6.0",

--- a/src/coordinator/config.py
+++ b/src/coordinator/config.py
@@ -291,6 +291,11 @@ class SearchConfig(BaseModel):
     # tool runs on any node with a hypothesis.
     require_validated: bool = True
     visit_max_content_tokens: int = 2048
+    # Full-text budget for the grounded-ideation (ResearchSearch) lane. Larger
+    # than visit_max_content_tokens so the model can read a paper's method /
+    # results sections, not just the abstract (roadmap 1.1d). The novelty-audit
+    # lane keeps the smaller visit_max_content_tokens (abstracts suffice there).
+    research_visit_tokens: int = 6000
     agent_max_turns: int = 12             # Phase 2
     # Per-search wall-clock cap (seconds). ``None`` = unlimited; the SearchAgent
     # runs to completion (still bounded by ``agent_max_turns``). Background

--- a/src/coordinator/tools/research_ctx.py
+++ b/src/coordinator/tools/research_ctx.py
@@ -138,10 +138,17 @@ async def _run_research(
     timeout = sc.agent_timeout
     if timeout is None or timeout <= 0:
         timeout = _RESEARCH_SOFT_TIMEOUT
+    # Grounded ideation reads for depth: give the visit tool a larger token
+    # budget so paper method/results sections survive truncation (roadmap 1.1d).
+    sc_research = sc.model_copy(update={
+        "visit_max_content_tokens": max(
+            getattr(sc, "research_visit_tokens", 0) or 0, sc.visit_max_content_tokens
+        ),
+    })
     try:
         agent = build_search_agent(
             provider=provider,
-            search_config=sc,
+            search_config=sc_research,
             cwd=config.cwd,
             meta_config=config,
             context_window=config.context_window,

--- a/src/core/tools/web/backends.py
+++ b/src/core/tools/web/backends.py
@@ -209,15 +209,16 @@ class ExaMcpBackend(SearchBackend):
     """Exa search via its hosted **MCP** server (``https://mcp.exa.ai/mcp``).
 
     Uses the MCP streamable-HTTP client (the same ``mcp`` package the Arbor MCP
-    server depends on) to call Exa's ``web_search_exa`` tool. Needs an Exa API
-    key (sent as the ``x-api-key`` header) and the optional ``mcp`` dependency
+    server depends on) to call Exa's ``web_search_exa`` tool. The hosted server
+    is **keyless** for basic use; pass an Exa API key (sent as ``x-api-key``) to
+    raise limits. Needs the optional ``mcp`` dependency
     (``pip install 'arbor-agent[mcp]'``).
     """
 
     name = "exa-mcp"
     DEFAULT_URL = "https://mcp.exa.ai/mcp"
 
-    def __init__(self, *, api_key: str, url: str | None = None,
+    def __init__(self, *, api_key: str | None = None, url: str | None = None,
                  tool: str = "web_search_exa", read_timeout: int = 30):
         self._api_key = api_key
         self._url = url or self.DEFAULT_URL
@@ -239,7 +240,7 @@ class ExaMcpBackend(SearchBackend):
                 "pip install 'arbor-agent[mcp]'"
             ) from exc
 
-        headers = {"x-api-key": self._api_key}
+        headers = {"x-api-key": self._api_key} if self._api_key else {}
         async with streamablehttp_client(self._url, headers=headers) as (read, write, _):
             async with ClientSession(read, write) as session:
                 await session.initialize()
@@ -255,14 +256,26 @@ class ExaMcpBackend(SearchBackend):
         ]
         return "\n".join(parts)
 
-    @staticmethod
-    def _parse(text: str) -> list[dict]:
-        """Defensively map Exa MCP's (text/JSON) result into search items."""
-        import json
+    @classmethod
+    def _parse(cls, text: str) -> list[dict]:
+        """Map Exa MCP's output into search items.
 
+        The hosted ``web_search_exa`` returns a plain-text block (``Title:`` /
+        ``URL:`` / ``Published:`` / ``Author:`` / ``Highlights:`` per result);
+        some configs may return JSON. Try JSON first, then the text format.
+        """
         text = (text or "").strip()
         if not text:
             return []
+        items = cls._parse_json(text)
+        if items:
+            return items
+        return cls._parse_text(text)
+
+    @staticmethod
+    def _parse_json(text: str) -> list[dict]:
+        import json
+
         try:
             data = json.loads(text)
         except json.JSONDecodeError:
@@ -288,6 +301,50 @@ class ExaMcpBackend(SearchBackend):
                 "title": r.get("title") or "No Title",
                 "snippets": _snippet(prefix, body),
             })
+        return items
+
+    @staticmethod
+    def _parse_text(text: str) -> list[dict]:
+        """Parse the ``Title:/URL:/Published:/Author:/Highlights:`` text block."""
+        items: list[dict] = []
+        cur: dict | None = None
+        hl: list[str] = []
+        in_hl = False
+
+        def flush() -> None:
+            if cur and cur.get("url"):
+                body = " ".join(s.strip() for s in hl if s.strip())
+                meta = [
+                    v for v in (cur.get("author", ""), cur.get("published", ""))
+                    if v and v != "N/A"
+                ]
+                items.append({
+                    "url": cur["url"],
+                    "title": cur.get("title") or "No Title",
+                    "snippets": _snippet(" · ".join(meta), body),
+                })
+
+        for line in text.splitlines():
+            s = line.strip()
+            if s.startswith("Title:"):
+                flush()
+                cur, hl, in_hl = {"title": s[6:].strip()}, [], False
+            elif cur is None:
+                continue
+            elif s.startswith("URL:"):
+                cur["url"] = s[4:].strip()
+                in_hl = False
+            elif s.startswith("Published:"):
+                cur["published"] = s[10:].strip()
+                in_hl = False
+            elif s.startswith("Author:"):
+                cur["author"] = s[7:].strip()
+                in_hl = False
+            elif s.startswith("Highlights:"):
+                in_hl = True
+            elif in_hl:
+                hl.append(line)
+        flush()
         return items
 
 
@@ -325,8 +382,8 @@ def resolve_backend_names(sc: Any) -> list[str]:
             continue
         if n == "exa" and not _exa_key(sc):
             continue
-        if n == "exa-mcp" and not _exa_key(sc):
-            continue
+        # exa-mcp is keyless (the hosted server works without a key); an
+        # optional Exa key just raises limits.
         usable.append(n)
     return list(dict.fromkeys(usable))
 

--- a/src/core/tools/web/keyless_visit.py
+++ b/src/core/tools/web/keyless_visit.py
@@ -61,6 +61,21 @@ def _clean_markdown(text: str) -> str:
     return text
 
 
+def _pdf_to_text(data: bytes) -> str:
+    """Extract text from PDF bytes via pypdf (lazy import; '' if unavailable)."""
+    try:
+        import io
+
+        from pypdf import PdfReader
+    except ImportError:
+        return ""
+    try:
+        reader = PdfReader(io.BytesIO(data))
+        return "\n".join((page.extract_text() or "") for page in reader.pages).strip()
+    except Exception:  # noqa: BLE001 - malformed/encrypted PDF
+        return ""
+
+
 class JinaVisitTool(WebVisitTool):
     """Keyless ``web_visit`` via the Jina reader, with a raw-requests fallback."""
 
@@ -117,12 +132,15 @@ class JinaVisitTool(WebVisitTool):
             resp = requests.get(
                 url, headers={"User-Agent": _BROWSER_UA}, timeout=self._timeout
             )
-            if resp.status_code == 200:
-                ctype = resp.headers.get("Content-Type", "")
-                if "html" in ctype or not ctype:
-                    return _html_to_text(resp.text)
-                if "text" in ctype or "json" in ctype:
-                    return resp.text
+            if resp.status_code != 200:
+                return ""
+            ctype = resp.headers.get("Content-Type", "").lower()
+            if "pdf" in ctype or url.lower().split("?")[0].endswith(".pdf"):
+                return _pdf_to_text(resp.content)
+            if "html" in ctype or not ctype:
+                return _html_to_text(resp.text)
+            if "text" in ctype or "json" in ctype:
+                return resp.text
         except requests.RequestException:
             pass
         return ""

--- a/tests/test_grounded_ideation.py
+++ b/tests/test_grounded_ideation.py
@@ -211,6 +211,25 @@ def test_research_search_passes_research_system_prompt(monkeypatch):
     assert captured.get("system_prompt") == RESEARCH_AGENT_SYSTEM_PROMPT
 
 
+def test_research_lane_uses_full_text_budget(monkeypatch):
+    """The research lane bumps the visit token budget so method sections survive."""
+    captured: dict = {}
+
+    def _fake_build(**kw):
+        captured.update(kw)
+        return _FakeResearchAgent()
+
+    monkeypatch.setattr(sa_agent, "build_search_agent", _fake_build)
+    cfg = _cfg(grounded=True)
+    cfg.search.visit_max_content_tokens = 2048
+    cfg.search.research_visit_tokens = 6000
+    tool = ResearchSearchTool(cwd=".", config=cfg, provider=_Provider())
+    asyncio.run(tool.execute(query="x"))
+
+    sc_passed = captured["search_config"]
+    assert sc_passed.visit_max_content_tokens == 6000  # bumped for full-text reads
+
+
 # ── integrity: separation of the two lanes ───────────────────────────────────
 
 def test_research_does_not_touch_tree(monkeypatch):

--- a/tests/test_keyless_visit.py
+++ b/tests/test_keyless_visit.py
@@ -116,3 +116,50 @@ def test_routing_without_alphaxiv_sends_all_to_jina():
         "https://www.alphaxiv.org/abs/2203.11171",
         "https://example.com/p",
     ]
+
+
+# ── PDF handling (roadmap 1.1d) ──────────────────────────────────────────────
+
+class _PdfResp:
+    def __init__(self, content, ctype="application/pdf", status=200):
+        self.content = content
+        self.text = ""
+        self.status_code = status
+        self.headers = {"Content-Type": ctype}
+
+
+def test_requests_routes_pdf_to_parser(monkeypatch):
+    monkeypatch.setattr(K, "_pdf_to_text", lambda data: "PARSED PDF TEXT")
+    monkeypatch.setattr(K.requests, "get", lambda *a, **k: _PdfResp(b"%PDF-1.4 ..."))
+    tool = JinaVisitTool(cwd=".", max_content_tokens=1000, use_jina=False)
+    out = asyncio.run(tool.execute(url="https://arxiv.org/pdf/2203.11171", goal="g"))
+    assert "PARSED PDF TEXT" in out
+
+
+def test_requests_pdf_by_url_suffix(monkeypatch):
+    # content-type is generic but the URL ends with .pdf → still parsed as PDF
+    monkeypatch.setattr(K, "_pdf_to_text", lambda data: "FROM SUFFIX")
+    monkeypatch.setattr(K.requests, "get",
+                        lambda *a, **k: _PdfResp(b"%PDF", ctype="application/octet-stream"))
+    tool = JinaVisitTool(cwd=".", max_content_tokens=1000, use_jina=False)
+    out = asyncio.run(tool.execute(url="https://host/paper.pdf", goal="g"))
+    assert "FROM SUFFIX" in out
+
+
+def test_pdf_to_text_graceful_on_garbage():
+    # Not a real PDF → returns "" instead of raising.
+    assert K._pdf_to_text(b"this is not a pdf") == ""
+
+
+def test_pdf_to_text_roundtrip():
+    # Build a real one-page PDF with pypdf and read it back.
+    import io
+
+    from pypdf import PdfWriter
+
+    w = PdfWriter()
+    w.add_blank_page(width=200, height=200)
+    buf = io.BytesIO()
+    w.write(buf)
+    # A blank page extracts to empty text but must not raise.
+    assert isinstance(K._pdf_to_text(buf.getvalue()), str)

--- a/tests/test_search_backends.py
+++ b/tests/test_search_backends.py
@@ -206,16 +206,48 @@ def test_exa_mcp_resolve_and_build():
     assert len(backends) == 1 and backends[0].name == "exa-mcp"
 
 
-def test_exa_mcp_dropped_without_key(monkeypatch):
+def test_exa_mcp_is_keyless(monkeypatch):
+    # The hosted Exa MCP server works without a key — exa-mcp must resolve
+    # even when no EXA_API_KEY is set.
     monkeypatch.delenv("EXA_API_KEY", raising=False)
     sc = SearchConfig(backends=["exa-mcp"])
-    assert resolve_backend_names(sc) == []
+    assert resolve_backend_names(sc) == ["exa-mcp"]
+    assert build_search_backends(sc)[0].name == "exa-mcp"
 
 
 def test_exa_mcp_uses_configured_url():
     sc = SearchConfig(backends=["exa-mcp"], exa_api_key="k", exa_mcp_url="https://my/mcp")
     backend = build_search_backends(sc)[0]
     assert backend._url == "https://my/mcp"
+
+
+def test_exa_mcp_parse_text_format():
+    # The real hosted web_search_exa returns a plain-text block, not JSON.
+    text = (
+        "Title: Self-Consistency Improves CoT\n"
+        "URL: https://arxiv.org/abs/2203.11171\n"
+        "Published: 2022-03-21\n"
+        "Author: N/A\n"
+        "Highlights:\n"
+        "Self-consistency samples diverse reasoning paths and votes.\n"
+        "It improves arithmetic reasoning.\n"
+        "\n"
+        "Title: RAG\n"
+        "URL: https://en.wikipedia.org/wiki/RAG\n"
+        "Published: N/A\n"
+        "Author: N/A\n"
+        "Highlights:\n"
+        "Retrieval augmented generation pulls external docs.\n"
+    )
+    items = ExaMcpBackend._parse(text)
+    assert [i["url"] for i in items] == [
+        "https://arxiv.org/abs/2203.11171",
+        "https://en.wikipedia.org/wiki/RAG",
+    ]
+    assert items[0]["title"] == "Self-Consistency Improves CoT"
+    assert "diverse reasoning paths" in items[0]["snippets"]
+    assert "2022-03-21" in items[0]["snippets"]  # Published kept (not N/A)
+    assert "N/A" not in items[1]["snippets"]      # N/A author/date dropped
 
 
 def test_exa_mcp_parse_results():
@@ -231,18 +263,18 @@ def test_exa_mcp_parse_results():
 
 
 def test_exa_mcp_parse_handles_garbage():
-    assert ExaMcpBackend._parse("not json") == []
+    assert ExaMcpBackend._parse("random prose with no markers") == []
     assert ExaMcpBackend._parse("") == []
 
 
 def test_exa_mcp_search_parses_tool_output(monkeypatch):
     """search() maps the MCP tool's text output without touching the network."""
-    canned = json.dumps({"results": [{"url": "https://e.com", "title": "E", "text": "b"}]})
+    canned = "Title: E\nURL: https://e.com\nPublished: N/A\nAuthor: N/A\nHighlights:\nbody\n"
 
     async def fake_call(self, query, max_results):
         return canned
 
     monkeypatch.setattr(ExaMcpBackend, "_call_tool", fake_call)
-    items = asyncio.run(ExaMcpBackend(api_key="k").search("q", 5))
-    assert items == [{"url": "https://e.com", "title": "E", "snippets": "b"}]
+    items = asyncio.run(ExaMcpBackend().search("q", 5))
+    assert items == [{"url": "https://e.com", "title": "E", "snippets": "body"}]
 


### PR DESCRIPTION
Follow-up to #23. Implements roadmap **§1.1 (d)** (full-text / PDF ingestion) and fixes two real bugs in the merged `exa-mcp` backend that surfaced when connecting to the live Exa MCP server.

## Full-text + PDF reads (§1.1 d)
The Jina reader already returns full page/PDF text, but visits were truncated to 2048 tokens — so the model only saw abstracts, not method sections.

- **`research_visit_tokens`** (default 6000): the grounded-ideation lane reads with a larger budget so a paper's **method / results sections survive truncation**. The novelty-audit lane keeps the smaller `visit_max_content_tokens` (abstracts are enough to judge prior art).
- **PDF parsing** in the keyless visit's `requests` fallback via `pypdf` (the Jina path already extracts PDF text). `pypdf` added as a dependency.
- Verified on a real arXiv PDF: `2048 tokens → 8.7K chars` (intro only); `6000 tokens → 21.9K chars` including the experiments / ablation sections.

## Fix exa-mcp (found by live testing)
- **Keyless**: `https://mcp.exa.ai/mcp` works without a key (an optional `EXA_API_KEY` only raises limits). `exa-mcp` now resolves without a key and sends `x-api-key` only when one is set. (Previously it was wrongly gated on a key.)
- **Text response**: `web_search_exa` returns a plain-text block (`Title:/URL:/Published:/Author:/Highlights:` per result), not JSON — the JSON-only parser returned nothing. Added a text-format parser (JSON still tried first).
- Verified end-to-end against the live server, keyless: real results parsed into the shared item contract.

## Docs
- Search guide (en/zh): PDF + full-text reading; `exa-mcp` marked keyless.

## Testing
- `313 passed, 2 skipped`; `ruff` clean; strict `mkdocs build` passes (en + zh).
- New tests: exa-mcp text/JSON parsing + keyless resolution; PDF routing + `pypdf` round-trip; research-lane full-text budget.