### PR TITLE
Add a benchmark scaffolder: scaffold_benchmark tool, CLI, and intake wiring

### DIFF
--- a/docs/zoo.md
+++ b/docs/zoo.md
@@ -139,7 +139,8 @@ held-out protocol rather than a convenient fiction.
    separate from the loop that later optimizes it, or the evaluation is self-certifying.
 
 !!! note "Coming next"
-    A `arbor benchmark add "<paper / repo / dataset>"` flow will let Arbor search for,
-    download, and *draft* a benchmark from one you name — then hand it to the verifier and
-    to you for acceptance. The format and verifier on this page are the landing pad for
-    that flow.
+    Use `arbor benchmark scaffold <dir> --style zoo` to generate a fresh pack skeleton
+    (front-matter contract, eval stub, dev/test split, PROVENANCE card) and verify it
+    structurally. A future `arbor benchmark add "<paper / repo / dataset>"` flow will
+    additionally *search for and draft* a benchmark from one you name, then hand it to the
+    verifier and to you for acceptance.

--- a/skills/arbor-agent-setup-intake/SKILL.md
+++ b/skills/arbor-agent-setup-intake/SKILL.md
@@ -49,6 +49,37 @@ The instruction passed to the coordinator must contain all five components:
 Do not prescribe a specific approach in the contract. The coordinator owns
 idea generation.
 
+## Scaffold When Not Eval-Ready
+
+Some targets arrive as code only — no runnable eval, no dev/held-out split, or
+no clean git repo. Do not dead-end: scaffold the *measurement plumbing* (never
+the solution) so the coordinator has a metric to optimize.
+
+- Prefer the keyless MCP tool `scaffold_benchmark`. `style="light"` produces a
+  runnable target (eval entrypoint printing `score:`, a dev/test split, an
+  editable `solution.py`); `style="zoo"` additionally writes the README
+  front-matter contract + `PROVENANCE.md` and runs the structural verifier.
+  Pass `git_init=true` to initialize and commit a baseline.
+- Fallback when the MCP server is absent:
+  `arbor benchmark scaffold <dir> [--style zoo] [--git-init]`.
+- Only scaffold after the user confirms what counts as success. The tool is
+  idempotent and non-destructive — report created vs skipped, never overwrite.
+
+## Persist The One-Screen Contract
+
+Once the contract is confirmed, persist it at the target root so it outlives the
+chat (the durable upgrade over an ephemeral on-screen contract):
+
+- `ARBOR_CONTRACT.md` — one screen: target dir, metric (name / command /
+  direction), baseline anchor, ambition, scope, dev/test discipline, edit
+  surface, and budget (suggested max cycles).
+- `research_config.yaml` — machine-readable, auto-detected by `arbor`:
+  `task` (the contract paragraph), `coordinator.max_cycles`,
+  `coordinator.ui.interaction_mode: review` (safest default; change on request).
+  Follow `examples/research_config.example.yaml`.
+
+These are written during setup, before handing the contract to the coordinator.
+
 ## Preflight Checks
 
 Mirror `arbor run` preflight:

--- a/skills/arbor-research-agent/SKILL.md
+++ b/skills/arbor-research-agent/SKILL.md
@@ -118,6 +118,11 @@ After intake:
 
 1. Load `arbor-agent-orchestrator`.
 2. Ensure `arbor-agent-setup-intake` receives the contract.
+   - If the target is not eval-ready (no runnable eval, no dev/test split, or a
+     dirty/absent git repo), the `arbor-agent-setup-intake` phase scaffolds the
+     measurement plumbing via the `scaffold_benchmark` tool and persists
+     `ARBOR_CONTRACT.md` + `research_config.yaml`. The entry point stays a thin
+     shell — it does not scaffold directly.
 3. Let the orchestrator load phase skills as needed:
    - `arbor-agent-coordinator`
    - `arbor-agent-ideate`

--- a/src/cli/commands/benchmark_cmd.py
+++ b/src/cli/commands/benchmark_cmd.py
@@ -105,7 +105,7 @@ def list_command(
 @benchmark_app.command("scaffold")
 def scaffold_command(
     target_dir: Path = typer.Argument(..., help="Directory to scaffold (created if missing)."),
-    name: str = typer.Option(None, "--name", help="Benchmark name (default: dir name)."),
+    name: str | None = typer.Option(None, "--name", help="Benchmark name (default: dir name)."),
     direction: str = typer.Option("maximize", "--direction", help="maximize | minimize."),
     style: str = typer.Option("light", "--style", help="light | zoo."),
     split_kind: str = typer.Option("seed_range", "--split-kind", help="seed_range | path."),

--- a/src/cli/commands/benchmark_cmd.py
+++ b/src/cli/commands/benchmark_cmd.py
@@ -10,6 +10,7 @@ Two subcommands:
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import typer
@@ -99,3 +100,54 @@ def list_command(
     width = max(len(p.name) for p in packs)
     for p in packs:
         typer.echo(f"  {p.name.ljust(width)}  {p.description}")
+
+
+@benchmark_app.command("scaffold")
+def scaffold_command(
+    target_dir: Path = typer.Argument(..., help="Directory to scaffold (created if missing)."),
+    name: str = typer.Option(None, "--name", help="Benchmark name (default: dir name)."),
+    direction: str = typer.Option("maximize", "--direction", help="maximize | minimize."),
+    style: str = typer.Option("light", "--style", help="light | zoo."),
+    split_kind: str = typer.Option("seed_range", "--split-kind", help="seed_range | path."),
+    entrypoint: str = typer.Option("eval.py", "--entrypoint", help="eval.py | eval.sh."),
+    baseline: float = typer.Option(0.0, "--baseline", help="Declared baseline score (zoo)."),
+    edit: list[str] = typer.Option(["solution.py"], "--edit", help="Editable file/glob (repeatable)."),
+    git_init: bool = typer.Option(False, "--git-init", help="git init + baseline commit."),
+) -> None:
+    """Scaffold the Arbor-ready reference folder (light) or a full zoo benchmark (zoo)."""
+    from ...zoo import scaffold_benchmark
+
+    target = target_dir.resolve()
+    pack_name = name or target.name
+    if split_kind == "path":
+        splits = {"kind": "path", "dev": ["data/dev/**"], "test": ["data/test/**"]}
+    else:
+        splits = {"kind": "seed_range", "dev": {"base": 1000, "count": 3},
+                  "test": {"base": 9000, "count": 3}}
+    try:
+        res = scaffold_benchmark(
+            target, name=pack_name, metric_direction=direction, splits=splits,
+            baseline={"score": baseline, "tolerance": 0.0, "kind": "exact"},
+            edit=edit, style=style, eval_entrypoint=entrypoint,
+        )
+    except ValueError as exc:
+        typer.secho(f"error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=2) from exc
+
+    if git_init and not (target / ".git").exists():
+        subprocess.run(["git", "init"], cwd=target, check=False)
+        subprocess.run(["git", "add", "-A"], cwd=target, check=False)
+        subprocess.run(["git", "commit", "-m", "baseline: scaffold Arbor benchmark structure"],
+                       cwd=target, check=False)
+
+    typer.echo(f"scaffolded {target.name} ({style}) …")
+    for f in res.created:
+        typer.secho(f"  created  {f}", fg=typer.colors.GREEN)
+    for f in res.skipped:
+        typer.secho(f"  skipped  {f} (exists)", fg=typer.colors.YELLOW)
+    for r in res.verify:
+        _render(r)
+    if res.next_steps:
+        typer.echo("\nnext steps:")
+        for s in res.next_steps:
+            typer.echo(f"  - {s}")

--- a/src/cli/commands/benchmark_cmd.py
+++ b/src/cli/commands/benchmark_cmd.py
@@ -121,9 +121,15 @@ def scaffold_command(
     pack_name = name or target.name
     if split_kind == "path":
         splits = {"kind": "path", "dev": ["data/dev/**"], "test": ["data/test/**"]}
-    else:
+    elif split_kind == "seed_range":
         splits = {"kind": "seed_range", "dev": {"base": 1000, "count": 3},
                   "test": {"base": 9000, "count": 3}}
+    else:
+        typer.secho(
+            f"error: --split-kind must be 'seed_range' or 'path', got {split_kind!r}",
+            fg=typer.colors.RED, err=True,
+        )
+        raise typer.Exit(code=2)
     try:
         res = scaffold_benchmark(
             target, name=pack_name, metric_direction=direction, splits=splits,

--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -37,6 +37,7 @@ TOOL_NAMES = (
     "git_merge_branch",
     "generate_report",
     "open_dashboard",
+    "scaffold_benchmark",
 )
 
 # Human-readable hint shown when the optional SDK is missing.
@@ -132,6 +133,35 @@ def build_server() -> Any:
             metric_direction=metric_direction, trunk_branch=trunk_branch,
             dataset_info=dataset_info, submission_path=submission_path,
             sample_submission_path=sample_submission_path,
+        )
+
+    # ── Benchmark scaffolding ──────────────────────────────────────────────────
+
+    @server.tool()
+    def scaffold_benchmark(
+        name: str,
+        metric_direction: str,
+        splits: dict[str, Any],
+        baseline: dict[str, Any] | None = None,
+        edit: list[str] | None = None,
+        eval_cmd: str | None = None,
+        style: str = "light",
+        eval_entrypoint: str = "eval.py",
+        git_init: bool = False,
+        cwd: str | None = None,
+    ) -> dict[str, Any]:
+        """Create the Arbor-ready reference folder in cwd.
+
+        style: light (runnable eval + dev/test split + editable solution.py) |
+        zoo (adds the README front-matter contract + PROVENANCE.md and runs the
+        structural verifier). Writes measurement plumbing only — never the
+        solution. Idempotent: existing files are reported as skipped. Takes no
+        run_name: scaffolding precedes a session, so it operates on a directory.
+        """
+        return ops.scaffold_benchmark(
+            _cwd(cwd), name=name, metric_direction=metric_direction, splits=splits,
+            baseline=baseline, edit=edit, eval_cmd=eval_cmd, style=style,
+            eval_entrypoint=eval_entrypoint, git_init=git_init,
         )
 
     # ── Evaluation ───────────────────────────────────────────────────────────

--- a/src/mcp/session_ops.py
+++ b/src/mcp/session_ops.py
@@ -324,6 +324,52 @@ def tree_set_meta(cwd: str | Path, run_name: str, **meta: Any) -> dict[str, Any]
     return {"meta_updated": sorted(updates)}
 
 
+# ── Benchmark scaffolding ───────────────────────────────────────────────────────
+
+
+def scaffold_benchmark(
+    cwd: str | Path,
+    *,
+    name: str,
+    metric_direction: str,
+    splits: dict[str, Any],
+    baseline: dict[str, Any] | None = None,
+    edit: list[str] | None = None,
+    eval_cmd: str | None = None,
+    style: str = "light",
+    eval_entrypoint: str = "eval.py",
+    git_init: bool = False,
+) -> dict[str, Any]:
+    """Create the Arbor reference folder under *cwd*; optionally git-init it.
+
+    Pure filesystem + git work, no LLM. Returns created/skipped files, the zoo
+    structural verify results (zoo style only), next-step hints, and whether a
+    baseline commit was made.
+    """
+    from ..zoo import scaffold_benchmark as _scaffold
+
+    target = Path(cwd)
+    res = _scaffold(
+        target, name=name, metric_direction=metric_direction, splits=splits,
+        baseline=baseline, edit=edit, eval_cmd=eval_cmd, style=style,
+        eval_entrypoint=eval_entrypoint,
+    )
+    committed = False
+    if git_init and not (target / ".git").exists():
+        git(target, "init")
+        git(target, "add", "-A")
+        rc, _ = git(target, "commit", "-m", "baseline: scaffold Arbor benchmark structure")
+        committed = rc == 0
+    return {
+        "created": res.created,
+        "skipped": res.skipped,
+        "verify": [{"name": r.name, "status": r.status, "message": r.message}
+                   for r in res.verify],
+        "next_steps": res.next_steps,
+        "git_committed": committed,
+    }
+
+
 # ── Evaluation ────────────────────────────────────────────────────────────────
 
 

--- a/src/zoo/__init__.py
+++ b/src/zoo/__init__.py
@@ -19,17 +19,20 @@ from .pack import (
     load_contract,
     read_front_matter,
 )
+from .scaffold import ScaffoldResult, scaffold_benchmark
 from .verify import VerifyResult, verify_pack
 
 __all__ = [
     "EVAL_ENTRYPOINTS",
     "Contract",
     "PackSummary",
+    "ScaffoldResult",
     "VerifyResult",
     "discover_packs",
     "find_eval_entrypoint",
     "is_pack_dir",
     "load_contract",
     "read_front_matter",
+    "scaffold_benchmark",
     "verify_pack",
 ]

--- a/src/zoo/scaffold.py
+++ b/src/zoo/scaffold.py
@@ -1,0 +1,260 @@
+"""``arbor.zoo.scaffold`` — create the reference benchmark folder structure.
+
+Deterministic, keyless file writer. Given the contract facts the host model
+decided during intake, it writes the *measurement plumbing* (eval entrypoint,
+dev/test split layout, an editable ``solution.py`` placeholder) and, for the
+``zoo`` style, the README front-matter contract + PROVENANCE card. It never
+writes the solution logic itself.
+
+Idempotent and non-destructive: an existing file is recorded under ``skipped``
+and never overwritten. Templates are rendered in-package (not copied from
+``arbor-zoo/_template``, which is not shipped in the wheel) so the front-matter
+is guaranteed to round-trip through :func:`arbor.zoo.pack.read_front_matter`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .pack import find_eval_entrypoint
+from .verify import VerifyResult, verify_pack
+
+_STYLES = ("light", "zoo")
+_ENTRYPOINTS = ("eval.py", "eval.sh")
+_DIRECTIONS = ("maximize", "minimize")
+
+
+@dataclass
+class ScaffoldResult:
+    """Outcome of one scaffold call."""
+
+    created: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    verify: list[VerifyResult] = field(default_factory=list)
+    next_steps: list[str] = field(default_factory=list)
+
+
+# ── templates ──────────────────────────────────────────────────────────────
+
+_SOLUTION = '''"""solution.py — the ONLY editable artifact (Arbor's edit surface).
+
+Replace this with a working baseline. It must be correct first; Arbor then
+optimizes it to improve the score. Keep the entry-point signature stable —
+``eval.py`` calls into it.
+"""
+
+from __future__ import annotations
+
+
+def solve(problem):
+    """TODO: return a solution for *problem* (the simplest correct baseline)."""
+    raise NotImplementedError("fill in the baseline solver")
+'''
+
+_EVAL_SH = '''#!/usr/bin/env bash
+# eval.sh — PROTECTED wrapper. Do not edit during a research run.
+#   bash eval.sh dev    # Arbor iterates here
+#   bash eval.sh test   # held-out gate
+# Prints a single "score: <float>" line.
+set -euo pipefail
+SPLIT="${1:-dev}"
+export OMP_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 MKL_NUM_THREADS=1 PYTHONHASHSEED=0
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PYTHON="${PYTHON:-python3}"
+exec "$PYTHON" "$HERE/eval.py" --split "$SPLIT"
+'''
+
+_PROVENANCE = """# Provenance
+
+All seven headings below are required. The verifier checks they are present; a
+maintainer reads and accepts the content before the benchmark ships.
+
+## Source
+
+Where the benchmark comes from — paper, repo, or competition, with a link, and
+how the data was collected or generated.
+
+## Setup & environment
+
+Hardware (CPU / GPU), Python version, install command, env vars, and any API
+keys, downloads, or services the user must provision. State whether it is offline.
+
+## Data source & license
+
+Where the data comes from, its license, and whether it may be redistributed.
+
+## Baseline implementation
+
+How the shipped baseline works — the approach, why it scores what it does, and
+what headroom it leaves for Arbor.
+
+## Baseline reproduction
+
+The number `eval dev` prints today (must match `baseline.score` in the README
+front-matter) and any gap from a published number.
+
+## Contamination assessment
+
+**Mandatory.** Could the test split be in a model's pre-training data? Is the
+held-out split truly disjoint from dev?
+
+## Caveats
+
+Known limitations — hardware sensitivity, metric noise, scope.
+"""
+
+
+def _eval_py(splits: dict[str, Any]) -> str:
+    """Render a protected eval.py stub for the declared split kind.
+
+    The stub catches NotImplementedError and prints ``score: 0.0`` so the metric
+    is always parseable before the baseline is filled in.
+    """
+    if splits.get("kind") == "path":
+        body = (
+            "    data_dir = Path(__file__).parent / \"data\" / split\n"
+            "    _instances = sorted(p for p in data_dir.glob(\"*\") if p.is_file())\n"
+            "    raise NotImplementedError(\"score solution.solve over the split's instances\")\n"
+        )
+        head = "from pathlib import Path\n"
+    else:
+        dev = splits.get("dev", {}) or {}
+        test = splits.get("test", {}) or {}
+        head = (
+            f"DEV_SEED_BASE = {int(dev.get('base', 1000))}\n"
+            f"TEST_SEED_BASE = {int(test.get('base', 9000))}\n"
+            f"DEV_COUNT = {int(dev.get('count', 3))}\n"
+            f"TEST_COUNT = {int(test.get('count', 3))}\n"
+        )
+        body = (
+            "    base = DEV_SEED_BASE if split == \"dev\" else TEST_SEED_BASE\n"
+            "    count = DEV_COUNT if split == \"dev\" else TEST_COUNT\n"
+            "    _seeds = [base + i for i in range(count)]\n"
+            "    raise NotImplementedError(\"compute the score from solution.solve\")\n"
+        )
+    return (
+        '"""eval.py — PROTECTED evaluation harness. Do not edit during a research run.\n\n'
+        "Prints exactly one line ``score: <float>`` for ``--split dev|test``. dev/test use\n"
+        "disjoint data; keep any constants in sync with the README front-matter ``splits:``.\n"
+        '"""\n\n'
+        "from __future__ import annotations\n\n"
+        "import argparse\n"
+        f"{head}\n\n"
+        "def evaluate(split: str) -> float:\n"
+        f"{body}\n\n"
+        "def main() -> None:\n"
+        "    parser = argparse.ArgumentParser()\n"
+        "    parser.add_argument(\"--split\", choices=[\"dev\", \"test\"], default=\"dev\")\n"
+        "    args = parser.parse_args()\n"
+        "    try:\n"
+        "        score = evaluate(args.split)\n"
+        "    except NotImplementedError:\n"
+        "        score = 0.0\n"
+        "    print(f\"score: {score:.4f}\")\n\n\n"
+        "if __name__ == \"__main__\":\n"
+        "    main()\n"
+    )
+
+
+def _readme(name: str, direction: str, splits: dict, baseline: dict,
+            edit: list[str], eval_cmd: str | None) -> str:
+    fm: dict[str, Any] = {"name": name, "metric": {"direction": direction}}
+    if eval_cmd:
+        fm["eval"] = {"cmd": eval_cmd}
+    fm["splits"] = splits
+    fm["baseline"] = baseline
+    fm["edit"] = edit
+    front = yaml.safe_dump(fm, sort_keys=False, default_flow_style=False)
+    body = (
+        f"# {name}\n\n"
+        "One-line summary of the benchmark.\n\n"
+        "## Task & metric\n"
+        "What the task is, what a solution looks like, the edit surface, and what is "
+        "off-limits (the eval harness and any ground-truth files).\n\n"
+        "## Run the baseline\n"
+        "```bash\n"
+        "python eval.py --split dev    # iterate here\n"
+        "python eval.py --split test   # held-out gate\n"
+        "```\n"
+        "Each prints one `score: <float>` line.\n\n"
+        "## Optimize with Arbor\n"
+        "Copy this folder out of the Arbor checkout (it uses git worktrees), then run "
+        "`arbor` and confirm the contract.\n\n"
+        "## Provenance\n"
+        "See [`PROVENANCE.md`](PROVENANCE.md).\n"
+    )
+    return f"---\n{front}---\n\n{body}"
+
+
+def _next_steps(style: str, res: ScaffoldResult) -> list[str]:
+    steps = [
+        "Fill in `solution.py` with the simplest correct baseline.",
+        "Implement `evaluate()` in `eval.py` to score `solution.solve`.",
+    ]
+    if style == "zoo":
+        steps.append("Complete `PROVENANCE.md` (all seven sections) before submitting.")
+        steps.append("Run `arbor benchmark verify <dir>` until it exits 0.")
+    return steps
+
+
+def scaffold_benchmark(
+    target: Path,
+    *,
+    name: str,
+    metric_direction: str,
+    splits: dict,
+    baseline: dict | None = None,
+    edit: list[str] | None = None,
+    eval_cmd: str | None = None,
+    style: str = "light",
+    eval_entrypoint: str = "eval.py",
+) -> ScaffoldResult:
+    """Scaffold the Arbor reference folder under *target*. See module docstring."""
+    if style not in _STYLES:
+        raise ValueError(f"style must be one of {_STYLES}, got {style!r}")
+    if metric_direction not in _DIRECTIONS:
+        raise ValueError(f"metric_direction must be one of {_DIRECTIONS}")
+    if eval_entrypoint not in _ENTRYPOINTS:
+        raise ValueError(f"eval_entrypoint must be one of {_ENTRYPOINTS}")
+
+    target = Path(target)
+    target.mkdir(parents=True, exist_ok=True)
+    edit = edit or ["solution.py"]
+    baseline = baseline or {"score": 0.0, "tolerance": 0.0, "kind": "exact"}
+    res = ScaffoldResult()
+
+    def write(rel: str, content: str) -> None:
+        p = target / rel
+        if p.exists():
+            res.skipped.append(rel)
+            return
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        res.created.append(rel)
+
+    existing = find_eval_entrypoint(target)
+    if existing is None:
+        write("eval.py", _eval_py(splits))
+        if eval_entrypoint == "eval.sh":
+            write("eval.sh", _EVAL_SH)
+    else:
+        res.skipped.append(existing)
+
+    if splits.get("kind") == "path":
+        write("data/dev/.gitkeep", "")
+        write("data/test/.gitkeep", "")
+
+    write("solution.py", _SOLUTION)
+
+    if style == "zoo":
+        write("README.md", _readme(name, metric_direction, splits, baseline, edit, eval_cmd))
+        write("PROVENANCE.md", _PROVENANCE)
+        write("requirements.txt", "# add runtime dependencies here\n")
+        res.verify = verify_pack(target, run_eval=False)
+
+    res.next_steps = _next_steps(style, res)
+    return res

--- a/src/zoo/scaffold.py
+++ b/src/zoo/scaffold.py
@@ -161,7 +161,7 @@ def _eval_py(splits: dict[str, Any]) -> str:
 
 
 def _readme(name: str, direction: str, splits: dict, baseline: dict,
-            edit: list[str], eval_cmd: str | None) -> str:
+            edit: list[str], eval_cmd: str | None, eval_entrypoint: str = "eval.py") -> str:
     fm: dict[str, Any] = {"name": name, "metric": {"direction": direction}}
     if eval_cmd:
         fm["eval"] = {"cmd": eval_cmd}
@@ -169,6 +169,12 @@ def _readme(name: str, direction: str, splits: dict, baseline: dict,
     fm["baseline"] = baseline
     fm["edit"] = edit
     front = yaml.safe_dump(fm, sort_keys=False, default_flow_style=False)
+    if eval_entrypoint == "eval.sh":
+        run = ("bash eval.sh dev    # iterate here\n"
+               "bash eval.sh test   # held-out gate\n")
+    else:
+        run = ("python eval.py --split dev    # iterate here\n"
+               "python eval.py --split test   # held-out gate\n")
     body = (
         f"# {name}\n\n"
         "One-line summary of the benchmark.\n\n"
@@ -177,8 +183,7 @@ def _readme(name: str, direction: str, splits: dict, baseline: dict,
         "off-limits (the eval harness and any ground-truth files).\n\n"
         "## Run the baseline\n"
         "```bash\n"
-        "python eval.py --split dev    # iterate here\n"
-        "python eval.py --split test   # held-out gate\n"
+        f"{run}"
         "```\n"
         "Each prints one `score: <float>` line.\n\n"
         "## Optimize with Arbor\n"
@@ -257,7 +262,8 @@ def scaffold_benchmark(
     write("solution.py", _SOLUTION)
 
     if style == "zoo":
-        write("README.md", _readme(name, metric_direction, splits, baseline, edit, eval_cmd))
+        write("README.md", _readme(name, metric_direction, splits, baseline, edit, eval_cmd,
+                                   eval_entrypoint))
         write("PROVENANCE.md", _PROVENANCE)
         write("requirements.txt", "# add runtime dependencies here\n")
         res.verify = verify_pack(target, run_eval=False)

--- a/src/zoo/scaffold.py
+++ b/src/zoo/scaffold.py
@@ -233,7 +233,9 @@ def scaffold_benchmark(
             res.skipped.append(rel)
             return
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content, encoding="utf-8")
+        # Force LF: a CRLF-translated eval.sh shebang ("…bash\r") is a broken
+        # interpreter on Unix, and the rest of the pack should stay LF too.
+        p.write_text(content, encoding="utf-8", newline="\n")
         res.created.append(rel)
 
     existing = find_eval_entrypoint(target)
@@ -245,8 +247,12 @@ def scaffold_benchmark(
         res.skipped.append(existing)
 
     if splits.get("kind") == "path":
-        write("data/dev/.gitkeep", "")
-        write("data/test/.gitkeep", "")
+        # Visible placeholder instances (not hidden .gitkeep): globs like
+        # `data/dev/**` skip dotfiles, so empty .gitkeep dirs would fail the
+        # splits-disjoint check. One example per split keeps the pack
+        # structurally verifiable; the user replaces them with real data.
+        write("data/dev/example_001.txt", "# replace with a real dev instance\n")
+        write("data/test/example_001.txt", "# replace with a real held-out test instance\n")
 
     write("solution.py", _SOLUTION)
 

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -30,3 +30,13 @@ def test_scaffold_zoo_renders_verify_rows(tmp_path: Path) -> None:
     assert (dest / "README.md").exists()
     assert (dest / "PROVENANCE.md").exists()
     assert "contract" in result.output  # a verify row name was rendered
+
+
+def test_scaffold_rejects_invalid_split_kind(tmp_path: Path) -> None:
+    dest = tmp_path / "demo"
+    result = runner.invoke(
+        benchmark_app,
+        ["scaffold", str(dest), "--name", "demo", "--split-kind", "paht"],
+    )
+    assert result.exit_code == 2
+    assert not dest.exists()  # bailed before writing anything

--- a/tests/test_benchmark_cli.py
+++ b/tests/test_benchmark_cli.py
@@ -1,0 +1,32 @@
+"""Tests for the `arbor benchmark scaffold` CLI subcommand."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from arbor.cli.commands.benchmark_cmd import benchmark_app
+
+runner = CliRunner()
+
+
+def test_scaffold_light_creates_files(tmp_path: Path) -> None:
+    dest = tmp_path / "demo"
+    result = runner.invoke(benchmark_app, ["scaffold", str(dest), "--name", "demo"])
+    assert result.exit_code == 0, result.output
+    assert (dest / "eval.py").exists()
+    assert (dest / "solution.py").exists()
+    assert "created" in result.output.lower()
+
+
+def test_scaffold_zoo_renders_verify_rows(tmp_path: Path) -> None:
+    dest = tmp_path / "demo"
+    result = runner.invoke(
+        benchmark_app,
+        ["scaffold", str(dest), "--name", "demo", "--style", "zoo"],
+    )
+    assert result.exit_code == 0, result.output
+    assert (dest / "README.md").exists()
+    assert (dest / "PROVENANCE.md").exists()
+    assert "contract" in result.output  # a verify row name was rendered

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -25,6 +25,7 @@ def test_tool_names_surface_is_stable() -> None:
         "tree_view", "tree_add_node", "tree_update_node", "tree_prune",
         "tree_set_meta", "eval_run", "worktree_create", "worktree_remove",
         "git_merge_branch", "generate_report", "open_dashboard",
+        "scaffold_benchmark",
     }
 
 

--- a/tests/test_mcp_session_ops.py
+++ b/tests/test_mcp_session_ops.py
@@ -303,3 +303,33 @@ def test_worktree_remove_refuses_paths_outside_scratch(tmp_path: Path) -> None:
         ops.worktree_remove(tmp_path, victim)
 
     assert victim.is_dir() and (victim / "keep.txt").exists()  # untouched
+
+
+# ── scaffold_benchmark ────────────────────────────────────────────────────────
+
+_SCAFFOLD_SPLITS = {
+    "kind": "seed_range",
+    "dev": {"base": 1000, "count": 3},
+    "test": {"base": 9000, "count": 3},
+}
+
+
+def test_scaffold_benchmark_light(tmp_path):
+    out = ops.scaffold_benchmark(
+        tmp_path, name="demo", metric_direction="maximize",
+        splits=_SCAFFOLD_SPLITS, style="light",
+    )
+    assert "eval.py" in out["created"]
+    assert out["verify"] == []
+    assert out["git_committed"] is False
+    assert isinstance(out["next_steps"], list)
+
+
+def test_scaffold_benchmark_zoo_with_git_init(tmp_path):
+    out = ops.scaffold_benchmark(
+        tmp_path, name="demo", metric_direction="maximize",
+        splits=_SCAFFOLD_SPLITS, style="zoo", git_init=True,
+    )
+    assert out["git_committed"] is True
+    assert (tmp_path / ".git").exists()
+    assert all(r["status"] != "fail" for r in out["verify"])

--- a/tests/test_prepare_benchmark_skill.py
+++ b/tests/test_prepare_benchmark_skill.py
@@ -1,0 +1,29 @@
+"""arbor-research-agent stays the public entry point; the setup-intake phase
+gains the scaffold + persisted-contract behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_SKILLS = Path(__file__).resolve().parent.parent / "skills"
+_ENTRY = _SKILLS / "arbor-research-agent" / "SKILL.md"
+_SETUP = _SKILLS / "arbor-agent-setup-intake" / "SKILL.md"
+
+
+def test_no_competing_entry_point_skill_exists() -> None:
+    # Scaffolding must live in the setup phase, not a new public entry point.
+    assert not (_SKILLS / "arbor-prepare-benchmark").exists()
+
+
+def test_entry_point_is_still_arbor_research_agent() -> None:
+    text = _ENTRY.read_text(encoding="utf-8")
+    assert "name: arbor-research-agent" in text
+    # It delegates the not-eval-ready case to the setup phase's scaffolder.
+    assert "scaffold" in text.lower()
+
+
+def test_setup_intake_drives_scaffold_and_persists_contract() -> None:
+    text = _SETUP.read_text(encoding="utf-8")
+    assert "scaffold_benchmark" in text
+    assert "ARBOR_CONTRACT.md" in text
+    assert "research_config.yaml" in text

--- a/tests/test_zoo_scaffold.py
+++ b/tests/test_zoo_scaffold.py
@@ -42,6 +42,19 @@ def test_light_eval_template_prints_parseable_score(tmp_path: Path) -> None:
     assert "score:" in proc.stdout
 
 
+def test_zoo_readme_run_commands_match_entrypoint(tmp_path: Path) -> None:
+    # eval.sh entrypoint → the README "Run the baseline" block uses bash eval.sh,
+    # not python eval.py.
+    scaffold_benchmark(tmp_path / "sh", name="demo", metric_direction="maximize",
+                       splits=_SEED_SPLITS, style="zoo", eval_entrypoint="eval.sh")
+    readme = (tmp_path / "sh" / "README.md").read_text()
+    assert "bash eval.sh dev" in readme and "python eval.py" not in readme
+    # eval.py entrypoint → python eval.py
+    scaffold_benchmark(tmp_path / "py", name="demo", metric_direction="maximize",
+                       splits=_SEED_SPLITS, style="zoo", eval_entrypoint="eval.py")
+    assert "python eval.py --split dev" in (tmp_path / "py" / "README.md").read_text()
+
+
 def test_path_split_creates_data_dirs(tmp_path: Path) -> None:
     res = scaffold_benchmark(tmp_path, name="demo", metric_direction="minimize",
                              splits=_PATH_SPLITS, style="light")

--- a/tests/test_zoo_scaffold.py
+++ b/tests/test_zoo_scaffold.py
@@ -1,0 +1,81 @@
+"""Tests for the zoo scaffolder (``arbor.zoo.scaffold``)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from arbor.zoo import ScaffoldResult, scaffold_benchmark, verify_pack
+
+_SEED_SPLITS = {
+    "kind": "seed_range",
+    "dev": {"base": 1000, "count": 3},
+    "test": {"base": 9000, "count": 3},
+}
+_PATH_SPLITS = {"kind": "path", "dev": ["data/dev/**"], "test": ["data/test/**"]}
+
+
+def test_light_scaffold_creates_eval_split_and_solution(tmp_path: Path) -> None:
+    res = scaffold_benchmark(
+        tmp_path, name="demo", metric_direction="maximize",
+        splits=_SEED_SPLITS, style="light",
+    )
+    assert isinstance(res, ScaffoldResult)
+    assert "eval.py" in res.created
+    assert "solution.py" in res.created
+    assert (tmp_path / "eval.py").exists()
+    assert (tmp_path / "solution.py").exists()
+    assert res.verify == []  # light style does not verify
+
+
+def test_light_eval_template_prints_parseable_score(tmp_path: Path) -> None:
+    scaffold_benchmark(tmp_path, name="demo", metric_direction="maximize",
+                       splits=_SEED_SPLITS, style="light")
+    proc = subprocess.run(
+        [sys.executable, str(tmp_path / "eval.py"), "--split", "dev"],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0
+    assert "score:" in proc.stdout
+
+
+def test_path_split_creates_data_dirs(tmp_path: Path) -> None:
+    res = scaffold_benchmark(tmp_path, name="demo", metric_direction="minimize",
+                             splits=_PATH_SPLITS, style="light")
+    assert "data/dev/.gitkeep" in res.created
+    assert "data/test/.gitkeep" in res.created
+
+
+def test_zoo_scaffold_passes_structural_verify(tmp_path: Path) -> None:
+    res = scaffold_benchmark(
+        tmp_path, name="demo", metric_direction="maximize",
+        splits=_SEED_SPLITS, baseline={"score": 0.0, "tolerance": 0.0, "kind": "exact"},
+        edit=["solution.py"], style="zoo",
+    )
+    assert "README.md" in res.created
+    assert "PROVENANCE.md" in res.created
+    # Re-verify directly to prove the round-trip is real (not just trusting res.verify).
+    results = verify_pack(tmp_path, run_eval=False)
+    fails = [r for r in results if r.status == "fail"]
+    assert not fails, f"structural verify failed: {[(r.name, r.message) for r in fails]}"
+
+
+def test_scaffold_is_idempotent(tmp_path: Path) -> None:
+    scaffold_benchmark(tmp_path, name="demo", metric_direction="maximize",
+                       splits=_SEED_SPLITS, style="zoo")
+    res2 = scaffold_benchmark(tmp_path, name="demo", metric_direction="maximize",
+                              splits=_SEED_SPLITS, style="zoo")
+    assert res2.created == []
+    assert "solution.py" in res2.skipped
+
+
+def test_invalid_style_and_direction_raise(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        scaffold_benchmark(tmp_path, name="x", metric_direction="maximize",
+                           splits=_SEED_SPLITS, style="bogus")
+    with pytest.raises(ValueError):
+        scaffold_benchmark(tmp_path, name="x", metric_direction="up",
+                           splits=_SEED_SPLITS, style="light")

--- a/tests/test_zoo_scaffold.py
+++ b/tests/test_zoo_scaffold.py
@@ -45,8 +45,28 @@ def test_light_eval_template_prints_parseable_score(tmp_path: Path) -> None:
 def test_path_split_creates_data_dirs(tmp_path: Path) -> None:
     res = scaffold_benchmark(tmp_path, name="demo", metric_direction="minimize",
                              splits=_PATH_SPLITS, style="light")
-    assert "data/dev/.gitkeep" in res.created
-    assert "data/test/.gitkeep" in res.created
+    # Visible placeholders (not hidden .gitkeep) so path globs can match them.
+    assert "data/dev/example_001.txt" in res.created
+    assert "data/test/example_001.txt" in res.created
+
+
+def test_zoo_path_split_passes_structural_verify(tmp_path: Path) -> None:
+    # Regression: path-kind zoo packs must also pass splits-disjoint, which
+    # requires glob-matchable (non-dotfile) data instances on both sides.
+    scaffold_benchmark(tmp_path, name="demo", metric_direction="maximize",
+                       splits=_PATH_SPLITS, style="zoo")
+    results = verify_pack(tmp_path, run_eval=False)
+    fails = [r for r in results if r.status == "fail"]
+    assert not fails, f"path-kind structural verify failed: {[(r.name, r.message) for r in fails]}"
+
+
+def test_generated_eval_sh_uses_lf_line_endings(tmp_path: Path) -> None:
+    # Regression: a CRLF shebang ("…bash\r") is a broken interpreter on Unix.
+    scaffold_benchmark(tmp_path, name="demo", metric_direction="maximize",
+                       splits=_SEED_SPLITS, style="light", eval_entrypoint="eval.sh")
+    raw = (tmp_path / "eval.sh").read_bytes()
+    assert b"\r\n" not in raw
+    assert raw.split(b"\n", 1)[0] == b"#!/usr/bin/env bash"
 
 
 def test_zoo_scaffold_passes_structural_verify(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a deterministic, keyless way to **create** the reference benchmark folder that Arbor runs on. Today the only path is to copy `arbor-zoo/_template` by hand (and `docs/zoo.md` flags an `arbor benchmark add` flow as "coming next"). This PR provides the scaffolding half of that flow and wires it into the intake phase, so a not-eval-ready repo can be made Arbor-ready in one step.

## What's included

- **`arbor.zoo.scaffold`** — `scaffold_benchmark()` writes the *measurement plumbing* only (never solution logic):
  - `style="light"` → a runnable eval entrypoint that prints `score:`, a dev/held-out split layout, and an editable `solution.py` placeholder.
  - `style="zoo"` → additionally the README front-matter contract + `PROVENANCE.md`, then runs `verify_pack(run_eval=False)` and returns the structural results.
  - Idempotent and non-destructive: existing files are reported as `skipped`, never overwritten. Templates are rendered in-package (not copied from `arbor-zoo/_template`) so the front-matter round-trips through the existing contract parser.
- **MCP tool `scaffold_benchmark`** — exposed through `arbor mcp` following the existing thin `session_ops` wrapper pattern (no LLM, no API key); optional `git_init` initializes and commits a baseline.
- **CLI `arbor benchmark scaffold <dir>`** — native entry point alongside `verify`/`list`, with `--style`, `--split-kind`, `--entrypoint`, `--baseline`, `--edit`, and `--git-init`.
- **Intake wiring** — the setup/intake phase now scaffolds a not-eval-ready target via the tool and persists a one-screen contract (`ARBOR_CONTRACT.md` + `research_config.yaml`); the existing public entry point stays a thin shell and delegates to it.

## Notes

- Generated files are written with LF endings so the `eval.sh` shebang stays valid across platforms.
- Path-kind packs are scaffolded with visible placeholder instances on both splits so the disjointness check is verifiable out of the box; the user replaces them with real data.
- Reuses `arbor.zoo.pack` and `arbor.zoo.verify` rather than duplicating the contract format or the verifier.

## Testing

New unit tests cover both styles, both split kinds, the structural round-trip through `verify_pack`, idempotency, line-ending correctness, the session op (with/without `git_init`), the MCP tool surface, the CLI (including invalid-input rejection), and the intake-skill wiring. The full suite passes (pre-existing, environment-specific failures unrelated to this change are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)