### PR TITLE
feat(zoo): `frozen:` field + `arbor benchmark add` collection spine

### DIFF
--- a/arbor-zoo/_template/README.md
+++ b/arbor-zoo/_template/README.md
@@ -18,6 +18,9 @@ baseline:
   tolerance: 0.0               # relative margin for reproduce + determinism
   kind: exact                  # exact | timing  (timing uses a ratio tolerance)
 edit: [solution.py]            # the editable surface (1+ files/globs); everything else is protected
+# frozen:                      # OPTIONAL — the freeze axis (what's held fixed for comparability)
+#   model: gpt-x               #   freeze the model (edit = scaffold/prompt), OR
+#   budget: "wall-clock 1h"    #   freeze only a budget (edit spans training+scaffold)
 ---
 
 # TODO_pack_name

--- a/docs/dev/benchmark-add.md
+++ b/docs/dev/benchmark-add.md
@@ -1,0 +1,287 @@
+# Design note — `arbor benchmark add` (the collection feature)
+
+> Status: design, not yet implemented. Captures the agreed architecture so the build
+> doesn't start from a blank page. Internal dev doc (not in the published nav).
+
+## Goal
+
+`arbor benchmark add "<spec>"` — point Arbor at a benchmark you name (a paper, a GitHub
+repo, a HuggingFace dataset id, or a plain description), and have it **acquire** the
+materials, **bring up a runnable baseline + eval**, **draft** the docs, and produce a
+*draft* zoo Task Pack that passes `arbor benchmark verify` — then hand it to a human to
+accept. This is roadmap §2.1's "半自动转换 / intake agent": **drafting is automated,
+acceptance is not, and it is never auto-accepted.**
+
+Hard invariant (§2.1): the agent that brings up a baseline here is **separate** from the
+loop that later optimizes it — collection stops *at* the baseline, never optimizes, so the
+evaluation can't be self-certifying.
+
+## Isolation — a separate top-level agent, not part of the research loop
+
+The collector is its **own top-level agent/pipeline**, parallel to `arbor run`, built on the
+shared `Agent` primitive (`src/core/agent.py:190`) the same way intake and the search-agent
+are. It is **not** a coordinator "subagent" (that term means an Executor the Coordinator
+spawns inside a research run) and it does **not** wire into the Coordinator/Executor loop.
+
+This separation is a **correctness requirement, not just tidiness**: per §2.1 the
+baseline-implementing agent must be distinct from the optimizing loop, or the eval is
+self-certifying.
+
+| Layer | Isolation guarantee |
+| --- | --- |
+| Code | lives in `src/zoo/`; `src/coordinator/` and `src/executor/` are untouched |
+| Runtime | its own CLI (`arbor benchmark add`), its own process; never shares a research run's idea tree / session |
+| Filesystem | works in the global cache + a scratch worktree; only touches `arbor-zoo/` on human accept |
+| Dependency | it **imports** shared building blocks (Agent, providers, search tools, worktree helpers, `verify_pack`) — but reuse ≠ coupling; the research loop neither calls it nor is called by it |
+
+Any helper agents the collector spawns (e.g. the Stage-2 baseline-bringup agent in a
+worktree) are **its own** children, sealed inside the collection pipeline — also separate
+from the Coordinator. Reuse the primitives; never hook into the main loop. (This is exactly
+why `src/zoo/verify.py` was built dependency-light, with no import of `cli`/`coordinator`.)
+
+## Positioning — runtime-sibling, product-subordinate
+
+"Separate process" and "co-equal feature" are two different axes; this feature wants the
+first, not the second. The core of Arbor is the research loop (`arbor run`). Collection is a
+**supporting tool** on the external-resources line (方向二) — it *stocks the zoo shelf*; the
+zoo is a resource that *feeds* `arbor run`. **It produces an input to Arbor; it is not
+another Arbor.** Guardrails that keep the hierarchy clear (so the build doesn't drift):
+
+- **CLI**: it stays `arbor benchmark add` — a tool subcommand under the `benchmark` noun,
+  sibling to `verify`/`list`. Never a top-level `arbor add` or a headline command. `arbor
+  run` remains *the* command.
+- **Code**: it lives in `src/zoo/` (a resource subsystem), not a new top-level subsystem
+  beside `coordinator/`/`executor/`.
+- **Docs**: it belongs under the Benchmark Zoo guide, not in the README/nav headline.
+- **Scope**: keep it lean and tool-shaped. A ballooning collector (its own GUI, its own
+  large surface) is exactly what would blur the project's main/supporting structure — a
+  second reason (beyond effort) to defer the GUI and keep v1 narrow.
+
+Runtime-independent, dependency-reusing, product-subordinate — all three hold at once.
+
+## Locked decisions
+
+- **v1 covers both acquisition modalities**: a GitHub repo that already ships an
+  eval/baseline, *and* a HuggingFace dataset with an API-judged metric. Kept cheap by a
+  pluggable `Acquirer` interface (below) — "both" is +1 acquirer, not a second pipeline.
+- **Downloads live in a global cache**: `~/.arbor/cache/benchmarks/<name>/` — reused across
+  projects, git-ignored, never committed. License decides whether data is copied into the
+  pack's `data/` or left in cache behind a `data/download.sh`.
+- **Autonomy**: after the human confirms the target (Stage 0), run autonomously all the way
+  to `verify` green, then hand the draft pack to the human for one acceptance gate.
+
+## Why this is NOT "building a second Claude Code"
+
+The agent runtime, search, isolated execution, eval, and the verifier already exist. The
+collection feature is a *vertical workflow* on top of them. Net-new is essentially a
+**download/data layer** + a **staged pipeline**. Reuse map:
+
+| Need | Reuse | Entry point |
+| --- | --- | --- |
+| Spawn an agent (prompt + tools → run to completion) | `Agent` + `agent.run()` | `src/core/agent.py:190` |
+| Interactive planning agent (read-only tools + a "done" signal tool) | `run_intake()` pattern | `src/cli/intake/repl.py:59`, `launch_tool.py:55` |
+| Search papers/repos, read pages + PDFs | web backends + `ResearchSearch` | `src/core/tools/web/`, `src/coordinator/tools/research_ctx.py:183` |
+| Isolated workspace, run shell, install deps | worktree + Bash/RunTraining | `src/mcp/session_ops.py:434`, `src/core/tools/bash.py:127`, `run_training.py:57` |
+| Run eval, parse a score | `eval_run` / `parse_score` | `src/mcp/session_ops.py:367`, `:169` |
+| **Decide the pack is good** | `verify_pack` (the Stage-2/4 oracle) | `src/zoo/verify.py` |
+| Provider/model/key inheritance | `create_provider` / `resolve_config` | `src/core/__init__.py`, `config_resolve.py` |
+
+Net-new (the real work):
+1. **Download/data layer** — `git clone`, file download (resume), HF dataset fetch; a global
+   cache + a small manifest (source, checksum, license). *Engineering-hard, bounded.*
+2. **`Acquirer` interface** — see below; isolates "both modalities".
+3. **`CreatePackTool` / pack writer** — scaffold `_template` → fill front-matter → place files.
+4. **The collector pipeline** — `src/zoo/collect.py`, staged, resumable by cache.
+5. **Stage system prompts** — resolve / baseline-bringup / doc-draft.
+6. **CLI** — `arbor benchmark add`.
+7. *(Later, not v1)* a review GUI — CLI diff + web UI suffices for v1.
+
+## Origination — where a zoo task comes from
+
+A zoo pack is **not "a dataset"; it is a locked optimization problem** =
+`data + frozen substrate + edit surface + metric + reference baseline`. That reframing
+drives how a task is sourced.
+
+**Two modes** (literature-grounding is the default, not a universal mandate):
+
+- **Literature-grounded** *(default for any benchmark that lives in a research literature)* —
+  the task is constructed *from a body of representative papers*. You cannot know the
+  community's de-facto eval harness, its general baseline, or the angles people climb from
+  without reading the work. The survey *is* the provenance.
+- **Constructed** *(escape hatch — synthetic / algorithmic / Kaggle / internal)* — the task is
+  defined by its own generator + eval, with no paper leaderboard behind it (e.g.
+  `algotune_knn`). Only light grounding (does a similar task exist? is the baseline sane?).
+
+**Three entry points** (increasingly bundled — pick by what you start from):
+
+- **Benchmark-first** — "collect GSM8K": resolve *this* benchmark's canonical source + baseline
+  + angles.
+- **Direction-first** — "survey search agents": survey a research **direction's** representative
+  papers and **harvest from that one survey both (a) the benchmarks the field actually competes
+  on, and (b) the baseline implementations those works share/open-source.** One direction → a
+  fan-out of `(benchmark, baseline)` candidates → the human picks which to onboard. The
+  directions in the landscape survey (agents, reasoning, RAG, efficiency, …) are these inputs.
+- **Work-first** *(the most bundled — primary engine for the frontier layer below)* — anchor on a
+  single representative **hot work** (a paper + its repo). One work is a *pre-packaged bundle*:
+  its **code = the baseline**, the **benchmark it reports on = the eval**, its **reported number
+  = the anchor to beat**, and its **mechanism = the angle** (Agentless → scaffold; a fine-tuning
+  paper → training; GEPA → prompt). Work-first does **not** drop the benchmark — it lets the work
+  *select and bundle* the benchmark + baseline + angle, so it is information-strictly-richer than
+  benchmark-first. The task becomes "beat this work's result by editing its mechanism."
+
+**Why harvesting matters operationally:** direction-first and work-first hand you a *runnable
+baseline* from a representative repo, so the survey **harvests** an implementation instead of
+inventing one — collapsing the hardest stage (Stage 2 bring-up) from *"invent a baseline + eval
+for an arbitrary repo"* down to *"make this harvested baseline run + wrap a clean dev/test eval."*
+Work-first goes furthest: the work *is* the baseline.
+
+**What the survey must pin (the per-benchmark task spec), all human-gated at Stage 0:**
+
+1. **Canonical source** — the repo/commit/harness people *actually run*, which is frequently a
+   representative work's curated data + eval, **not** the upstream official dataset. Pin to a
+   commit; record *why this is the de-facto standard* in PROVENANCE.
+2. **Reference baseline** — surveyed across several papers, distinguishing four reference points:
+   `floor` (naive), **`general baseline`** (the community-standard method → the front-matter
+   `baseline.score` anchor), `SOTA` (the target ceiling), and a paper's own implementation.
+   Prefer harvesting the general baseline's *implementation* from a representative repo.
+3. **Angle decomposition + the freeze axis** — the *same dataset is climbed from different
+   angles* (prompt vs fine-tune vs tool-scaffold). **The angle *is* the pack:** its `edit:`
+   surface + what it freezes + its metric. One dataset → several angle-locked packs. The
+   coverage of each pack is set by **what it freezes**, a deliberate choice (recorded in the
+   optional `frozen:` field):
+   - **Freeze the model** (`edit: [scaffold]`) → covers only scaffold/inference works; clean
+     attribution, cheap, narrow.
+   - **Freeze only a budget** (compute/cost/wall-clock; `edit: [scaffold, training, data]`) →
+     covers *all* mechanisms (training, RL, scaffold) on equal footing; comparability comes from
+     the fixed budget, not a fixed substrate. This is MLE-bench's design and stays controlled
+     (budget + held-out), not a trophy board — but needs a single budget currency (wall-clock on
+     fixed hardware) and the compute to actually run those mechanisms.
+   Arbor's ideation is mechanism-agnostic: give it a broad `edit:` + a budget and its Idea Tree
+   branches across train/scaffold/ensemble on its own, and `merge` combines them — coverage that
+   single-mechanism papers can't give. The practical ceiling is compute: on 4×A100 the training
+   mechanism is only reachable for small-model benchmarks; SWE-bench realistically freezes the
+   model. **A pack must declare its freeze** so "improvement" is attributable and two runs are
+   comparable.
+
+### Two layers — stable core + work-anchored frontier
+
+Work-first and benchmark/synthetic-first are not either/or; they serve the zoo's two purposes:
+
+- **Stable core** *(benchmark / synthetic-anchored, e.g. `algotune_knn`)* — Arbor's own
+  **regression harness**: stable, cheap, deterministic, doesn't drift with the hype cycle.
+- **Frontier shelf** *(work-anchored)* — a rotating set of "beat this hot method" tasks built
+  **work-first**. Current and exciting — this is the "刷 hot directions" use case. Direction-first
+  surveys naturally surface the works that populate this shelf.
+
+The core keeps Arbor honestly regression-tested; the frontier tracks the field. Work-first is the
+primary engine for the frontier; the constructed mode anchors the core.
+
+### Guardrail — work-first is one line away from AutoSOTA
+
+Work-first ("anchor on a paper, beat its number") sits *closest* to the AutoSOTA niche the
+roadmap explicitly says Arbor is **not**. The line that keeps it legitimate:
+
+| AutoSOTA (do NOT become) | work-first zoo (OK) |
+| --- | --- |
+| Maintain a per-paper **SOTA scoreboard** | Use a representative work as the **starting artifact + objective definition** for a reusable, verifiable task |
+| Deliverable = *our* trophy numbers | Deliverable = a **re-runnable task** (frozen objective + held-out) others can take |
+
+So: papers/works are used to *position and fairly-baseline a reusable optimization task* — never
+to catalogue how many papers we beat. Keep that line and work-first stays inside the roadmap.
+Practical filter (which also dodges reproduction hell): only onboard works whose **repo runs**,
+**fit 4×A100/API**, and **report a clean benchmark + metric**.
+
+**Format impact:** minimal. The angle is the existing `edit:`/protected mechanism; canonical
+source, baseline rationale, and the floor/SOTA reference points live in PROVENANCE prose. At
+most add two *optional* front-matter fields — `frozen:` (pinned base model / budget) and
+`references:` (floor/sota; the anchor stays `baseline.score`) — rather than re-fattening the
+format we deliberately slimmed.
+
+## Pipeline
+
+
+```
+spec ─▶ Stage 0 Survey & Disambiguate (literature survey + search)
+          input = a research DIRECTION ("search agents") or a single benchmark ("GSM8K")
+          → read N representative papers; harvest (benchmark, baseline-impl) candidates
+          → per benchmark, a task spec: canonical source+commit, baselines
+            (floor/general/SOTA), angle decomposition, frozen substrate, feasibility
+          → HUMAN gate: confirm source + baseline + angle(s)  (a direction → several packs)
+        Stage 1 Acquire (deterministic + download layer)        ── Acquirer.acquire()
+          → clone/download into ~/.arbor/cache/benchmarks/<name>/, record provenance
+          → license: copy into pack/data OR write data/download.sh
+        Stage 2 Bring up baseline + eval (baseline agent in a worktree)
+          → make the HARVESTED baseline run (not invent one); wrap a clean dev/test eval
+            that prints `score:`; fill README front-matter contract
+          → ORACLE: loop until `verify_pack` is green (or report blockers)
+        Stage 3 Draft docs (agent, reuse Stage-0 survey material)
+          → README body (4 sections) + PROVENANCE (7 sections incl. baseline impl +
+            DRAFT contamination assessment)
+        Stage 4 Verify + HUMAN accept
+          → final `arbor benchmark verify`; show draft pack + report; human edits/accepts
+          → on accept: move into arbor-zoo/<name>/   (never auto-accept)
+```
+
+Orchestration is a plain deterministic Python sequence (not a heavyweight multi-agent
+framework): each stage spawns an `Agent` with a stage-specific prompt + toolset; the
+verifier is the success oracle for Stages 2 and 4; resume keys off the global cache. A
+direction-first Stage 0 fans out — one survey can spawn several packs (Stages 1–4 per
+benchmark). Stage 0 is the heaviest and most human-gated stage, and it reuses the
+already-shipped grounding search (§1.1 / `ResearchSearch`) rather than new machinery.
+
+## The `Acquirer` interface (keeps "both modalities" cheap)
+
+```python
+@dataclass
+class Sources:        # produced by Stage 0 (the survey)
+    kind: str         # "git" | "hf"
+    locator: str      # canonical repo URL+commit | HF dataset id
+    license: str | None
+    baseline_ref: str # harvested baseline impl: repo path / method to reproduce (de-risks Stage 2)
+    angle: str        # the locked angle: what's editable vs frozen (base model, budget)
+    notes: str        # metric, floor/general/SOTA reference points, feasibility
+
+@dataclass
+class Acquired:       # produced by Stage 1
+    cache_dir: Path   # ~/.arbor/cache/benchmarks/<name>/
+    manifest: dict    # {source, checksum, license, files}
+
+class Acquirer(Protocol):
+    def matches(self, spec: str) -> bool: ...
+    def resolve(self, spec: str, search) -> Sources: ...      # may use ResearchSearch
+    def acquire(self, sources: Sources, cache_dir: Path) -> Acquired: ...
+    def bringup_recipe(self) -> str: ...   # extra system-prompt guidance for Stage 2
+```
+
+v1 ships two: `GitRepoAcquirer` (clone; bring-up = adapt the repo's existing eval) and
+`HFDatasetAcquirer` (fetch dataset; bring-up = construct an API-judged scorer + dev/test
+split). Everything after Stage 1 is shared.
+
+## Honest difficulty ranking
+
+1. **Stage 2 generality** — "make a research repo run and emit a score on a clean held-out
+   split". Research-hard, but it is *Arbor's home turf* (the executor already does this) and
+   the verifier bounds "done". **Direction-first Stage 0 de-risks this a lot**: when the survey
+   harvests an existing baseline impl from a representative repo, Stage 2 becomes "make *this*
+   run + wrap an eval" rather than "invent a baseline". Difficulty still swings by benchmark: a
+   repo with a clean eval is easy; one needing an invented scorer + split is hard.
+2. **Stage 0 survey quality** — picking the *de-facto* canonical source, the *general* baseline
+   (not an arbitrary one), and the right angle decomposition. This is judgement-heavy and is
+   exactly why Stage 0 is human-gated; a wrong call here makes a clean-looking but unfair pack.
+3. **Stage 1 acquisition for messy real sources** — auth, large files, HF/Kaggle quirks,
+   license gating. Engineering-hard, bounded.
+4. **Honest contamination / held-out judgement** — needs a human. Automate the *draft*, never
+   the *acceptance*.
+
+## Phased build order (sequences "both" safely)
+
+1. **Shared spine + git modality**: global cache + manifest, `CreatePackTool`, the
+   `collect.py` pipeline, `GitRepoAcquirer`, Stage prompts, `arbor benchmark add` CLI →
+   prove end-to-end on ONE real repo-with-eval (the algotune_knn analogue for collection).
+2. **HF + API modality**: add `HFDatasetAcquirer` + the API-judged bring-up recipe → prove on
+   one reasoning/agent benchmark.
+3. **Hardening**: resume, cache dedup/locking, license edge cases, better blocker reporting.
+4. *(Later)* review GUI / web-UI acceptance surface.
+
+Each phase ends with one real, human-accepted pack — coverage proven by working examples,
+not by breadth of untested code paths.

--- a/docs/dev/benchmark-backlog.md
+++ b/docs/dev/benchmark-backlog.md
@@ -1,0 +1,66 @@
+# Benchmark backlog — candidates for `arbor benchmark add`
+
+> Internal dev doc. A researched shortlist of benchmarks worth collecting into the zoo,
+> seen through the format's lens: each is a *locked optimization problem*
+> (`data + frozen substrate + edit surface + metric + reference baseline`). See the
+> design in [benchmark-add.md](benchmark-add.md) and the format in
+> [../zoo.md](../zoo.md). Sources/baselines below are **candidates to confirm at Stage 0**
+> (the survey pins the exact canonical source + commit + general baseline), not final.
+
+Columns: **angle** = what Arbor edits (the pack); **frozen** = the freeze axis;
+**baseline** = harvestable reference impl; **acquirer** = git / hf.
+
+## Tier 1 — start here (clean eval + harvestable baseline + fits 4×A100/API)
+
+| Benchmark | Angle (edit) | Frozen | Harvestable baseline | Compute | Acquirer |
+| --- | --- | --- | --- | --- | --- |
+| **KernelBench** | a GPU kernel (CUDA/Triton) | reference op + shapes | torch reference in [repo](https://github.com/ScalingIntelligence/KernelBench) | 1×A100 | git |
+| **SWE-bench Lite** | the coding-agent scaffold | base model + tasks/tests | [mini-SWE-agent](https://github.com/SWE-agent/mini-swe-agent) / [Agentless](https://arxiv.org/abs/2407.01489) | API | git |
+| **MLE-bench (Lite)** | the ML-eng pipeline | data + budget (24h) | [AIDE](https://github.com/WecoAI/aideml) (wired in [mle-bench/agents](https://github.com/openai/mle-bench/blob/main/agents/README.md)) | 4×A100 | git |
+| **AlgoTune** (more tasks) | the numerical solver | reference solver + eval | reference in [repo](https://github.com/oripress/AlgoTune) | CPU | git |
+| **nanoGPT speedrun** | the training code | token/compute budget | `records/` in [modded-nanogpt](https://github.com/KellerJordan/modded-nanogpt) | 4×A100 (scaled) | git |
+
+`algotune_knn` is already shipped (the dogfood pack); AlgoTune here = adding more tasks.
+
+## Tier 2 — strong, API/HF (prompt / agent / RAG / reasoning angles)
+
+| Benchmark | Angle (edit) | Frozen | Harvestable baseline | Compute | Acquirer |
+| --- | --- | --- | --- | --- | --- |
+| **GAIA** | a deep-research agent | base model | [Open Deep Research / smolagents](https://huggingface.co/blog/open-deep-research) | API | hf+git |
+| **τ-bench** | a tool-use agent policy | base model | repo's function-calling agent ([tau-bench](https://github.com/sierra-research/tau-bench)) | API | git |
+| **BIRD (text-to-SQL)** | a text→SQL pipeline | base model | [ContextualAI/bird-sql](https://github.com/ContextualAI/bird-sql) | API (+opt small model) | git+hf |
+| **GSM8K / HotpotQA (DSPy)** | a prompt/pipeline | base model | [DSPy](https://dspy.ai/deep-dive/data-handling/built-in-datasets/) CoT/ReAct | API | git+hf |
+| **LongBench v2 / RULER** | a long-context / RAG method | base model | retrieval baseline in repo | API | git+hf |
+
+## Tier 3 — feasible but heavier / baseline needs building / extra env
+
+LiveCodeBench · BigCodeBench (code-gen scaffold) · GPQA + reasoning scaffold (test-time
+compute) · WebArena / OSWorld (need browser/OS env — heavy) · BEIR / MTEB (retriever / reranker,
+small GPU).
+
+## Out of scope (measure a frozen model, or need sim/hardware)
+
+Pure multimodal/video QA · embodied VLA robotics · safety red-teaming. These evaluate a model
+rather than optimizing an artifact, or need hardware/sim Arbor can't drive.
+
+## Same dataset → multiple angle-locked packs
+
+A dataset is not a pack; the angle is. e.g. **GSM8K** splits into:
+
+| Pack | edit | frozen | measures |
+| --- | --- | --- | --- |
+| `gsm8k_prompt_opt` | prompt | model | prompt engineering |
+| `gsm8k_tool_scaffold` | reasoning scaffold | model | test-time inference framework |
+| `gsm8k_finetune` | training code + weights | budget | fine-tuning method |
+
+## First moves (validate both acquirers)
+
+Pick **one git-with-eval** + **one HF-dataset+API** so v1 exercises both `Acquirer`s end-to-end:
+
+1. **KernelBench** (git, GPU) — the GPU analogue of `algotune_knn`; clean eval + reference
+   baseline in-repo.
+2. **GSM8K-via-DSPy** *or* **GPQA + scaffold** (hf+api) — data on HF, metric via API, baseline
+   harvested from DSPy.
+
+These two prove the shared spine across both modalities; the rest of each tier follows once the
+pipeline is real.

--- a/docs/zoo.md
+++ b/docs/zoo.md
@@ -61,12 +61,22 @@ baseline:
   tolerance: 0.30              # relative margin for reproduce + determinism
   kind: timing                 # exact | timing  (timing uses a ratio tolerance)
 edit: [solution.py]            # editable files/globs (1+); everything else is protected
+frozen:                        # OPTIONAL — the freeze axis (what's held fixed for comparability)
+  model: gpt-x                 #   freeze the model → measures the edited artifact, not a model swap
+  budget: "wall-clock 1h"      #   or freeze only a budget → any mechanism (train/scaffold) competes
 ---
 ```
 
 For a path-based split, write `splits: {kind: path, dev: ["data/dev/**"], test: ["data/test/**"]}`.
 The same field names reuse the [plugin](plugins.md) vocabulary, so a verified benchmark
 can be turned into a plugin with little rework.
+
+The optional **`frozen:`** field is the *freeze axis* — what a pack holds fixed so an
+improvement is attributable and two runs are comparable. Freeze the **model** (`edit:` is a
+scaffold/prompt) to measure the edited method; or freeze only a **budget** (compute/wall-clock,
+with `edit:` spanning training + scaffold + data) to let *any* mechanism compete on equal
+footing (MLE-bench style). Omit it for self-contained artifact-optimization tasks (e.g.
+`algotune_knn`) that freeze nothing but the protected eval.
 
 ### `README.md` body — four fixed sections
 

--- a/docs/zoo.zh.md
+++ b/docs/zoo.zh.md
@@ -53,11 +53,19 @@ baseline:
   tolerance: 0.30              # reproduce + determinism 的相对容差
   kind: timing                 # exact | timing（timing 用比值容差）
 edit: [solution.py]            # 可编辑文件/glob（≥1）；其余一切受保护
+frozen:                        # 可选 —— 冻结轴（为可比性固定什么）
+  model: gpt-x                 #   冻模型 → 测被编辑的方法，而非换模型
+  budget: "wall-clock 1h"      #   或只冻预算 → 任意机制（训练/scaffold）平等竞争
 ---
 ```
 
 基于路径的 split 写成 `splits: {kind: path, dev: ["data/dev/**"], test: ["data/test/**"]}`。
 这些字段名复用[插件](plugins.md)词汇，所以一个通过校验的基准稍加改动即可变成 plugin。
+
+可选的 **`frozen:`** 是*冻结轴*——一个 pack 固定什么，好让"提升"可归因、两次 run 可比。**冻模型**
+（`edit:` 是 scaffold/prompt）测被编辑的方法；或只**冻预算**（算力/wall-clock，`edit:` 覆盖训练+
+scaffold+数据）让任意机制平等竞争（MLE-bench 式）。自包含的 artifact 优化任务（如 `algotune_knn`，
+只冻受保护的 eval）可省略它。
 
 ### `README.md` 正文 —— 四个固定章节
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,11 @@ theme:
     - search.suggest
     - search.highlight
 
+# Internal dev/design notes live under docs/dev/ but are not part of the
+# published site (they cross-link each other and would trip strict link checks).
+exclude_docs: |
+  dev/
+
 nav:
   - Home: index.md
   - Getting Started:

--- a/src/cli/commands/benchmark_cmd.py
+++ b/src/cli/commands/benchmark_cmd.py
@@ -1,21 +1,34 @@
-"""`arbor benchmark` — verify and list Task Packs in the zoo.
+"""`arbor benchmark` — verify, list, scaffold, and collect Task Packs in the zoo.
 
-Two subcommands:
+Subcommands:
 
 * ``arbor benchmark verify <pack-dir>`` — run the gate that decides whether a pack
   is allowed into the zoo. Exits non-zero if any check fails.
 * ``arbor benchmark list [zoo-dir]`` — print a plain index of packs (not a ranked
   leaderboard).
+* ``arbor benchmark scaffold <dir>`` — write the measurement plumbing (light) or a
+  full zoo benchmark (zoo) into an existing local directory.
+* ``arbor benchmark add <spec> --name <name>`` — acquire a benchmark (git repo / HF
+  dataset) into the global cache and scaffold a draft pack (Phase 1: the deterministic
+  spine; the agent-driven survey + bring-up are the next sub-phase).
 """
 
 from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import Any
 
 import typer
 
-from ...zoo import VerifyResult, discover_packs, find_eval_entrypoint, verify_pack
+from ...zoo import (
+    VerifyResult,
+    collect,
+    discover_packs,
+    find_eval_entrypoint,
+    select_acquirer,
+    verify_pack,
+)
 
 benchmark_app = typer.Typer(
     name="benchmark",
@@ -119,6 +132,7 @@ def scaffold_command(
 
     target = target_dir.resolve()
     pack_name = name or target.name
+    splits: dict[str, Any]
     if split_kind == "path":
         splits = {"kind": "path", "dev": ["data/dev/**"], "test": ["data/test/**"]}
     elif split_kind == "seed_range":
@@ -157,3 +171,54 @@ def scaffold_command(
         typer.echo("\nnext steps:")
         for s in res.next_steps:
             typer.echo(f"  - {s}")
+
+
+@benchmark_app.command("add")
+def add_command(
+    spec: str = typer.Argument(
+        ...,
+        help="A git repo URL (optionally `url@commit`) or a HF dataset (`hf:<id>`).",
+    ),
+    name: str = typer.Option(
+        ..., "--name", "-n",
+        help="Pack name (the arbor-zoo/<name> folder).",
+    ),
+    dest: Path = typer.Option(
+        Path("arbor-zoo"), "--dest",
+        help="Where to write the draft pack (default: ./arbor-zoo).",
+    ),
+) -> None:
+    """Acquire a benchmark and scaffold a draft pack (deterministic spine).
+
+    Phase 1: selects an acquirer, clones/downloads into the global cache, scaffolds a
+    draft pack, and structurally verifies it. The agent-driven survey + baseline bring-up
+    are the next sub-phase — this leaves a draft for a human (or a later agent pass) to
+    complete, then `arbor benchmark verify` and accept.
+    """
+    if select_acquirer(spec) is None:
+        typer.secho(
+            f"error: no acquirer matched {spec!r} — expected a git URL or `hf:<dataset-id>`",
+            fg=typer.colors.RED, err=True,
+        )
+        raise typer.Exit(code=2)
+
+    typer.echo(f"collecting {name} from {spec} …")
+    try:
+        result = collect(spec, name=name, dest_root=dest.resolve())
+    except RuntimeError as exc:
+        typer.secho(f"error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+
+    for note in result.notes:
+        typer.echo(f"  • {note}")
+
+    fails = [r for r in result.verify_results if r.status == "fail"]
+    if result.draft_pack_dir:
+        typer.secho(f"\ndraft pack: {result.draft_pack_dir}", fg=typer.colors.GREEN)
+    typer.echo(f"structural verify: {len(fails)} fail(s) "
+               f"(eval not run — the draft eval is a stub)")
+
+    typer.secho("\nstill to do (drafting is automated, acceptance is not):",
+                fg=typer.colors.YELLOW)
+    for step in result.pending:
+        typer.echo(f"  - {step}")

--- a/src/cli/commands/benchmark_cmd.py
+++ b/src/cli/commands/benchmark_cmd.py
@@ -157,8 +157,12 @@ def scaffold_command(
     if git_init and not (target / ".git").exists():
         subprocess.run(["git", "init"], cwd=target, check=False)
         subprocess.run(["git", "add", "-A"], cwd=target, check=False)
-        subprocess.run(["git", "commit", "-m", "baseline: scaffold Arbor benchmark structure"],
-                       cwd=target, check=False)
+        # Ephemeral identity so the commit succeeds without a global git user.
+        subprocess.run(
+            ["git", "-c", "user.email=arbor@localhost", "-c", "user.name=Arbor",
+             "commit", "-m", "baseline: scaffold Arbor benchmark structure"],
+            cwd=target, check=False,
+        )
 
     typer.echo(f"scaffolded {target.name} ({style}) …")
     for f in res.created:

--- a/src/mcp/session_ops.py
+++ b/src/mcp/session_ops.py
@@ -358,7 +358,14 @@ def scaffold_benchmark(
     if git_init and not (target / ".git").exists():
         git(target, "init")
         git(target, "add", "-A")
-        rc, _ = git(target, "commit", "-m", "baseline: scaffold Arbor benchmark structure")
+        # Commit with an ephemeral identity (-c) so the baseline commit succeeds on
+        # machines/CI with no global git user configured, without mutating the
+        # user's git config.
+        rc, _ = git(
+            target,
+            "-c", "user.email=arbor@localhost", "-c", "user.name=Arbor",
+            "commit", "-m", "baseline: scaffold Arbor benchmark structure",
+        )
         committed = rc == 0
     return {
         "created": res.created,

--- a/src/zoo/__init__.py
+++ b/src/zoo/__init__.py
@@ -1,14 +1,20 @@
-"""``arbor.zoo`` — the benchmark format and its verifier.
+"""``arbor.zoo`` — the benchmark format, its verifier, scaffolder, and collection spine.
 
 A benchmark is a self-contained directory under ``arbor-zoo/``: a README whose YAML
 front-matter is a tiny machine contract and whose body is prose, a PROVENANCE card, a
-runnable baseline (one or more code files), and a protected eval entrypoint. This
-package provides pack discovery + the contract (:mod:`~arbor.zoo.pack`) and the
-``arbor benchmark verify`` gate (:mod:`~arbor.zoo.verify`). See ``docs/zoo.md``.
+runnable baseline (one or more code files), and a protected eval entrypoint. This package
+provides pack discovery + the contract (:mod:`~arbor.zoo.pack`), the
+``arbor benchmark verify`` gate (:mod:`~arbor.zoo.verify`), the scaffolder
+(:mod:`~arbor.zoo.scaffold`), and the ``arbor benchmark add`` collection spine
+(:mod:`~arbor.zoo.acquire` / :mod:`~arbor.zoo.cache` / :mod:`~arbor.zoo.collect`).
+See ``docs/zoo.md``.
 """
 
 from __future__ import annotations
 
+from .acquire import Acquired, Acquirer, GitRepoAcquirer, Sources, select_acquirer
+from .cache import Manifest, benchmark_cache_dir, cache_root
+from .collect import CollectResult, collect
 from .pack import (
     EVAL_ENTRYPOINTS,
     Contract,
@@ -24,15 +30,25 @@ from .verify import VerifyResult, verify_pack
 
 __all__ = [
     "EVAL_ENTRYPOINTS",
+    "Acquired",
+    "Acquirer",
+    "CollectResult",
     "Contract",
+    "GitRepoAcquirer",
+    "Manifest",
     "PackSummary",
     "ScaffoldResult",
+    "Sources",
     "VerifyResult",
+    "benchmark_cache_dir",
+    "cache_root",
+    "collect",
     "discover_packs",
     "find_eval_entrypoint",
     "is_pack_dir",
     "load_contract",
     "read_front_matter",
     "scaffold_benchmark",
+    "select_acquirer",
     "verify_pack",
 ]

--- a/src/zoo/acquire.py
+++ b/src/zoo/acquire.py
@@ -1,0 +1,166 @@
+"""Acquirers — fetch a benchmark's materials into the global cache.
+
+The collection pipeline is modality-agnostic after acquisition: an :class:`Acquirer`
+turns a user spec (a repo URL, a HF dataset id) into a cached, provenance-recorded set
+of materials, and everything downstream (scaffold → bring-up → verify) is shared. v1
+ships :class:`GitRepoAcquirer` (fully implemented) and :class:`HFDatasetAcquirer`
+(needs the optional ``huggingface_hub`` dependency).
+
+Network/auth/large-file handling lives here; keep it bounded and fail loudly.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from .cache import Manifest, SourceRecord, benchmark_cache_dir, record_source
+
+
+@dataclass
+class Sources:
+    """What Stage 0 (the survey) resolved a spec to. See benchmark-add.md."""
+
+    kind: str                    # "git" | "hf"
+    locator: str                 # canonical repo URL+commit | HF dataset id
+    license: str | None = None
+    baseline_ref: str = ""       # harvested baseline impl (de-risks bring-up)
+    angle: str = ""              # the locked angle: what's editable vs frozen
+    commit: str | None = None    # pinned commit / revision
+    notes: str = ""              # metric, floor/general/SOTA points, feasibility
+
+
+@dataclass
+class Acquired:
+    """What Stage 1 produced: cached materials + the provenance manifest."""
+
+    cache_dir: Path
+    manifest: Manifest
+    materials_dir: Path          # where the clone/download landed inside cache_dir
+
+
+@runtime_checkable
+class Acquirer(Protocol):
+    kind: str
+
+    def matches(self, spec: str) -> bool: ...
+    def resolve(self, spec: str) -> Sources: ...
+    def acquire(self, sources: Sources, name: str) -> Acquired: ...
+    def bringup_recipe(self) -> str: ...
+
+
+def _run(cmd: list[str], cwd: Path | None = None) -> str:
+    """Run a subprocess, raising RuntimeError with output on failure."""
+    proc = subprocess.run(cmd, cwd=str(cwd) if cwd else None,
+                          capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"command failed ({' '.join(cmd)}):\n{proc.stdout}\n{proc.stderr}")
+    return proc.stdout.strip()
+
+
+_GIT_SPEC = re.compile(r"^(https?://|git@|file://).*|.*\.git$|^[\w.-]+/[\w.-]+$")
+_HF_SPEC = re.compile(r"^hf:.+|^datasets/.+")
+
+
+@dataclass
+class GitRepoAcquirer:
+    """Clone a git repo (optionally at a pinned commit) into the cache."""
+
+    kind: str = "git"
+
+    def matches(self, spec: str) -> bool:
+        s = spec.strip()
+        if _HF_SPEC.match(s):
+            return False
+        return bool(_GIT_SPEC.match(s)) or Path(s).expanduser().is_dir()
+
+    def resolve(self, spec: str) -> Sources:
+        # "<url>@<commit>" pins a commit.
+        locator, _, commit = spec.strip().partition("@")
+        return Sources(kind="git", locator=locator, commit=commit or None,
+                       notes="git repo (confirm canonical source + commit at Stage 0)")
+
+    def acquire(self, sources: Sources, name: str) -> Acquired:
+        cache_dir = benchmark_cache_dir(name, create=True)
+        materials = cache_dir / "repo"
+        if materials.exists():
+            # already cloned — reuse the cache (idempotent)
+            pass
+        else:
+            depth = [] if sources.commit else ["--depth", "1"]
+            _run(["git", "clone", *depth, sources.locator, str(materials)])
+            if sources.commit:
+                _run(["git", "fetch", "--depth", "1", "origin", sources.commit], cwd=materials)
+                _run(["git", "checkout", sources.commit], cwd=materials)
+        head = None
+        try:
+            head = _run(["git", "rev-parse", "HEAD"], cwd=materials)
+        except RuntimeError:
+            pass
+        manifest = record_source(
+            cache_dir, name,
+            SourceRecord(kind="git", locator=sources.locator,
+                         commit=sources.commit or head, license=sources.license),
+        )
+        return Acquired(cache_dir=cache_dir, manifest=manifest, materials_dir=materials)
+
+    def bringup_recipe(self) -> str:
+        return (
+            "The repo ships a runnable baseline + eval. Make it run (install deps), then "
+            "wrap a clean `eval.sh dev|test` that prints `score:` on a held-out split. "
+            "Harvest the existing baseline — do not invent one."
+        )
+
+
+@dataclass
+class HFDatasetAcquirer:
+    """Fetch a HuggingFace dataset into the cache (needs ``huggingface_hub``)."""
+
+    kind: str = "hf"
+
+    def matches(self, spec: str) -> bool:
+        return bool(_HF_SPEC.match(spec.strip()))
+
+    def resolve(self, spec: str) -> Sources:
+        locator = spec.strip().removeprefix("hf:").removeprefix("datasets/")
+        return Sources(kind="hf", locator=locator,
+                       notes="HF dataset (build an API-judged scorer + dev/test split at Stage 2)")
+
+    def acquire(self, sources: Sources, name: str) -> Acquired:
+        try:
+            from huggingface_hub import snapshot_download
+        except ImportError as exc:
+            raise RuntimeError(
+                "HF acquisition needs `huggingface_hub` — `pip install huggingface_hub`"
+            ) from exc
+        cache_dir = benchmark_cache_dir(name, create=True)
+        materials = Path(snapshot_download(repo_id=sources.locator, repo_type="dataset",
+                                           local_dir=str(cache_dir / "data")))
+        manifest = record_source(
+            cache_dir, name,
+            SourceRecord(kind="hf", locator=sources.locator,
+                         commit=sources.commit, license=sources.license),
+        )
+        return Acquired(cache_dir=cache_dir, manifest=manifest, materials_dir=materials)
+
+    def bringup_recipe(self) -> str:
+        return (
+            "The dataset has no harness. Construct an API-judged scorer that prints `score:` "
+            "and a disjoint dev/test split; harvest the general baseline (e.g. a DSPy CoT "
+            "pipeline) rather than inventing one."
+        )
+
+
+# Registry, in match-precedence order (HF before git so `datasets/x` wins).
+ACQUIRERS: list[Acquirer] = [HFDatasetAcquirer(), GitRepoAcquirer()]
+
+
+def select_acquirer(spec: str) -> Acquirer | None:
+    """Return the first acquirer that matches *spec*, or None."""
+    for a in ACQUIRERS:
+        if a.matches(spec):
+            return a
+    return None

--- a/src/zoo/cache.py
+++ b/src/zoo/cache.py
@@ -1,0 +1,107 @@
+"""Global benchmark cache + manifest for the collection feature.
+
+Acquired benchmark materials (cloned repos, downloaded datasets) live in a global,
+git-ignored cache *outside* the Arbor checkout — reused across projects, never
+committed. Each cached benchmark records a small ``manifest.json`` of where its
+materials came from (source, commit, license, checksum) so provenance is traceable.
+
+The cache root is ``~/.arbor/cache/benchmarks`` by default, overridable via the
+``ARBOR_BENCHMARK_CACHE`` env var (used by tests and for relocating the cache).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+CACHE_ENV = "ARBOR_BENCHMARK_CACHE"
+MANIFEST_NAME = "manifest.json"
+
+
+def cache_root() -> Path:
+    """The global benchmark cache root (env override, else ``~/.arbor/cache/benchmarks``)."""
+    override = os.environ.get(CACHE_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return (Path.home() / ".arbor" / "cache" / "benchmarks").resolve()
+
+
+def benchmark_cache_dir(name: str, *, create: bool = False) -> Path:
+    """The cache directory for benchmark *name*."""
+    d = cache_root() / name
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@dataclass
+class SourceRecord:
+    """One acquired source (a repo clone, a dataset download, …)."""
+
+    kind: str                       # "git" | "hf" | "url" | …
+    locator: str                    # repo URL | dataset id | file URL
+    commit: str | None = None       # pinned git commit / dataset revision
+    license: str | None = None
+    checksum: str | None = None     # sha256 of the key artifact, when applicable
+
+    def to_dict(self) -> dict[str, Any]:
+        return {k: v for k, v in self.__dict__.items() if v is not None}
+
+
+@dataclass
+class Manifest:
+    """What was fetched for a cached benchmark, and from where."""
+
+    name: str
+    sources: list[SourceRecord] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "sources": [s.to_dict() for s in self.sources]}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Manifest":
+        return cls(
+            name=data.get("name", ""),
+            sources=[SourceRecord(**s) for s in data.get("sources", [])],
+        )
+
+
+def load_manifest(cache_dir: Path) -> Manifest | None:
+    """Read ``manifest.json`` from *cache_dir*, or None if absent/unreadable."""
+    path = cache_dir / MANIFEST_NAME
+    if not path.exists():
+        return None
+    try:
+        return Manifest.from_dict(json.loads(path.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def save_manifest(cache_dir: Path, manifest: Manifest) -> None:
+    """Write ``manifest.json`` into *cache_dir* (created if needed)."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / MANIFEST_NAME).write_text(
+        json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+
+
+def record_source(cache_dir: Path, name: str, source: SourceRecord) -> Manifest:
+    """Append *source* to the benchmark's manifest (creating it if needed) and persist."""
+    manifest = load_manifest(cache_dir) or Manifest(name=name)
+    manifest.name = manifest.name or name
+    manifest.sources.append(source)
+    save_manifest(cache_dir, manifest)
+    return manifest
+
+
+def sha256_file(path: Path) -> str:
+    """Hex sha256 of a file (for checksumming a key downloaded artifact)."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()

--- a/src/zoo/collect.py
+++ b/src/zoo/collect.py
@@ -1,0 +1,96 @@
+"""The `arbor benchmark add` collection pipeline.
+
+Orchestrates: select an acquirer → acquire materials into the global cache → scaffold a
+draft pack → structurally verify it. This is the **deterministic spine** (Phase 1). The
+*agent-driven* stages — Stage 0 survey (canonical source / baseline / angle) and Stage 2
+baseline bring-up — need a live LLM provider and are the next sub-phase; they are invoked
+only when a provider is supplied, and otherwise the pipeline produces a draft for a human
+(or a later agent pass) to complete. See docs/dev/benchmark-add.md.
+
+Isolation: this is a standalone flow built on the shared `Agent` runtime; it never wires
+into the Coordinator/Executor research loop (a §2.1 correctness requirement).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .acquire import Acquired, select_acquirer
+from .scaffold import scaffold_benchmark
+from .verify import VerifyResult
+
+
+@dataclass
+class CollectResult:
+    """Outcome of a collection run."""
+
+    name: str
+    acquired: Acquired | None = None
+    draft_pack_dir: Path | None = None
+    verify_results: list[VerifyResult] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    ok: bool = False                       # spine completed (acquire + scaffold + verify ran)
+
+    @property
+    def pending(self) -> list[str]:
+        """Human/agent steps still required before the pack can be accepted."""
+        return [
+            "Stage 0 survey: confirm canonical source, general baseline, angle + frozen substrate",
+            "Stage 2 bring-up: make the harvested baseline run; real eval.sh prints score: on dev/test",
+            "Fill PROVENANCE (baseline implementation + contamination) and README sections",
+            "Re-run `arbor benchmark verify` until green, then human-accept into arbor-zoo/",
+        ]
+
+
+def collect(
+    spec: str,
+    *,
+    name: str,
+    dest_root: Path,
+    provider: Any | None = None,
+) -> CollectResult:
+    """Run the collection spine for *spec*, writing a draft pack under *dest_root*/<name>.
+
+    *provider* is reserved for the agent-driven stages (survey / bring-up); when None,
+    the deterministic spine runs and the draft is left for a human or a later agent pass.
+    """
+    result = CollectResult(name=name)
+
+    acquirer = select_acquirer(spec)
+    if acquirer is None:
+        result.notes.append(f"no acquirer matched spec {spec!r} (expected a git URL or hf: id)")
+        return result
+    result.notes.append(f"acquirer: {acquirer.kind}")
+
+    # ── Stage 1: acquire into the global cache ──────────────────────────────
+    sources = acquirer.resolve(spec)
+    result.acquired = acquirer.acquire(sources, name)
+    result.notes.append(f"acquired into {result.acquired.cache_dir}")
+
+    # ── Stage 0/2 (agent-driven) — next sub-phase ───────────────────────────
+    # With a provider, the survey would fill the contract (canonical source / baseline /
+    # angle) and bring-up would make the harvested baseline run. Until then we scaffold a
+    # draft from defaults for a human (or a later agent pass) to complete.
+    if provider is not None:
+        result.notes.append("provider supplied, but agent stages (survey/bring-up) are not yet "
+                            "implemented — scaffolding a draft for completion")
+
+    # ── Stage 3: scaffold the draft pack (reuses the zoo scaffolder) ─────────
+    draft_dir = dest_root / name
+    scaffold_res = scaffold_benchmark(
+        draft_dir, name=name, metric_direction="maximize",
+        splits={"kind": "seed_range",
+                "dev": {"base": 1000, "count": 3},
+                "test": {"base": 9000, "count": 3}},
+        style="zoo",
+    )
+    result.draft_pack_dir = draft_dir
+    result.notes.append(
+        f"scaffolded draft pack at {draft_dir} ({len(scaffold_res.created)} files)")
+
+    # ── Stage 4 (structural): the zoo scaffolder already ran verify(run_eval=False) ──
+    result.verify_results = scaffold_res.verify
+    result.ok = True
+    return result

--- a/src/zoo/pack.py
+++ b/src/zoo/pack.py
@@ -49,6 +49,7 @@ class Contract:
     splits: dict[str, Any] = field(default_factory=dict)    # {kind, dev, test}
     baseline: dict[str, Any] = field(default_factory=dict)  # {score, tolerance, kind}
     edit: list[str] = field(default_factory=list)           # editable globs (1+); rest is protected
+    frozen: dict[str, Any] = field(default_factory=dict)    # {model, budget} — the freeze axis (optional)
     present: bool = False                                    # was there front-matter at all?
 
 
@@ -86,6 +87,7 @@ def load_contract(pack_dir: Path) -> Contract:
         splits=data.get("splits", {}) or {},
         baseline=data.get("baseline", {}) or {},
         edit=data.get("edit", []) or [],
+        frozen=data.get("frozen", {}) or {},
         present=True,
     )
 

--- a/src/zoo/verify.py
+++ b/src/zoo/verify.py
@@ -156,7 +156,14 @@ def _check_contract(ctx: _Ctx) -> VerifyResult:
             f"front-matter missing/invalid: {', '.join(missing)}",
             "see the front-matter schema in docs/zoo.md",
         )
-    return VerifyResult("contract", "pass", "front-matter contract complete")
+    # `frozen:` is optional (the freeze axis); if present it must be a mapping.
+    if c.frozen and not isinstance(c.frozen, dict):
+        return VerifyResult(
+            "contract", "fail", "frozen: must be a mapping (e.g. {model: …, budget: …})",
+            "declare what is held fixed so improvement is attributable",
+        )
+    note = f"; freeze: {', '.join(sorted(c.frozen))}" if isinstance(c.frozen, dict) and c.frozen else ""
+    return VerifyResult("contract", "pass", f"front-matter contract complete{note}")
 
 
 def _check_readme_sections(ctx: _Ctx) -> VerifyResult:

--- a/tests/test_zoo_algotune_knn.py
+++ b/tests/test_zoo_algotune_knn.py
@@ -37,6 +37,14 @@ requires_numpy = pytest.mark.skipif(
 requires_zoo = pytest.mark.skipif(not _ZOO.is_dir(), reason="arbor-zoo not present")
 
 
+@pytest.fixture(autouse=True)
+def _stable_knn_timing(monkeypatch):
+    """Raise the median-of-N timing reps + instances so the speedup ratio is stable
+    under CI load (the timing metric is otherwise noisy run-to-run)."""
+    monkeypatch.setenv("KNN_TRIALS", "9")
+    monkeypatch.setenv("KNN_INSTANCES", "5")
+
+
 @requires_zoo
 @requires_numpy
 def test_algotune_knn_verifies_clean() -> None:

--- a/tests/test_zoo_collect.py
+++ b/tests/test_zoo_collect.py
@@ -1,0 +1,138 @@
+"""Tests for the collection spine (cache / acquire / scaffold / collect / CLI).
+
+Deterministic only — no LLM, no network. Git acquisition is exercised against a local
+throwaway repo; the cache is redirected via ARBOR_BENCHMARK_CACHE.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from arbor.cli.app import app
+from arbor.zoo import (
+    GitRepoAcquirer,
+    Sources,
+    cache_root,
+    collect,
+    select_acquirer,
+)
+from arbor.zoo.cache import Manifest, SourceRecord, load_manifest, record_source, sha256_file
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+def _make_repo(root: Path) -> Path:
+    """A throwaway git repo with one commit (the 'benchmark' to clone)."""
+    repo = root / "src_repo"
+    repo.mkdir(parents=True)
+    (repo / "README.md").write_text("# upstream benchmark\n")
+    (repo / "baseline.py").write_text("def solve(x): return x\n")
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "t@example.com", cwd=repo)
+    _git("config", "user.name", "T", cwd=repo)
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-qm", "baseline", cwd=repo)
+    return repo
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch) -> Path:
+    d = tmp_path / "cache"
+    monkeypatch.setenv("ARBOR_BENCHMARK_CACHE", str(d))
+    return d
+
+
+# ── cache ─────────────────────────────────────────────────────────────────────
+
+def test_cache_root_env_override(cache: Path) -> None:
+    assert cache_root() == cache.resolve()
+
+
+def test_manifest_roundtrip(cache: Path) -> None:
+    d = cache / "demo"
+    record_source(d, "demo", SourceRecord(kind="git", locator="u", commit="abc", license="MIT"))
+    m = load_manifest(d)
+    assert isinstance(m, Manifest) and m.name == "demo"
+    assert m.sources[0].locator == "u" and m.sources[0].commit == "abc"
+
+
+def test_sha256_file(tmp_path: Path) -> None:
+    f = tmp_path / "x"
+    f.write_bytes(b"hello")
+    assert sha256_file(f) == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+
+# ── acquire ───────────────────────────────────────────────────────────────────
+
+def test_select_acquirer_git_vs_hf() -> None:
+    assert select_acquirer("https://github.com/o/r").kind == "git"
+    assert select_acquirer("git@github.com:o/r.git").kind == "git"
+    assert select_acquirer("hf:openai/gsm8k").kind == "hf"
+    assert select_acquirer("datasets/openai/gsm8k").kind == "hf"
+    assert select_acquirer("not a spec at all !!!") is None
+
+
+def test_git_acquirer_clones_and_records(cache: Path, tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    acq = GitRepoAcquirer()
+    assert acq.matches(str(repo))  # a local git dir matches
+    acquired = acq.acquire(Sources(kind="git", locator=str(repo)), "demo")
+    assert (acquired.materials_dir / "baseline.py").exists()
+    assert acquired.manifest.sources[0].kind == "git"
+    assert acquired.manifest.sources[0].commit  # HEAD recorded
+
+
+def test_git_acquirer_idempotent(cache: Path, tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    acq = GitRepoAcquirer()
+    acq.acquire(Sources(kind="git", locator=str(repo)), "demo")
+    # second call reuses the existing clone (no crash)
+    again = acq.acquire(Sources(kind="git", locator=str(repo)), "demo")
+    assert (again.materials_dir / "baseline.py").exists()
+
+
+# ── scaffold ──────────────────────────────────────────────────────────────────
+# (the scaffolder itself is covered by tests/test_zoo_scaffold.py; collect's use of
+# it is exercised by test_collect_spine below)
+
+
+# ── collect (end-to-end spine) ─────────────────────────────────────────────────
+
+def test_collect_spine(cache: Path, tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    zoo = tmp_path / "zoo"
+    result = collect(str(repo), name="demo", dest_root=zoo)
+    assert result.ok
+    assert result.acquired is not None and (result.acquired.materials_dir / "baseline.py").exists()
+    assert result.draft_pack_dir == zoo / "demo" and (zoo / "demo" / "README.md").exists()
+    assert [r for r in result.verify_results if r.status == "fail"] == []
+    assert result.pending  # human/agent steps remain
+
+
+def test_collect_unknown_spec(tmp_path: Path) -> None:
+    result = collect("?!? not a spec", name="x", dest_root=tmp_path)
+    assert not result.ok and any("no acquirer" in n for n in result.notes)
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def test_cli_add(cache: Path, tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path)
+    zoo = tmp_path / "zoo"
+    result = CliRunner().invoke(
+        app, ["benchmark", "add", str(repo), "--name", "demo", "--dest", str(zoo)]
+    )
+    assert result.exit_code == 0, result.output
+    assert (zoo / "demo" / "README.md").exists()
+    assert "still to do" in result.output
+
+
+def test_cli_add_rejects_bad_spec(tmp_path: Path) -> None:
+    result = CliRunner().invoke(app, ["benchmark", "add", "!!!", "--name", "x"])
+    assert result.exit_code == 2

--- a/tests/test_zoo_pack.py
+++ b/tests/test_zoo_pack.py
@@ -86,6 +86,15 @@ def test_load_contract_absent_is_not_present(tmp_path: Path) -> None:
     assert load_contract(pack).present is False
 
 
+def test_load_contract_frozen_optional(tmp_path: Path) -> None:
+    # absent → empty dict
+    assert load_contract(_make_pack(tmp_path, "a")).frozen == {}
+    # present → loaded
+    fm = _FM.replace("edit: [solution.py]\n", "edit: [solution.py]\nfrozen: {model: gpt-x}\n")
+    pack = _make_pack(tmp_path, "b", readme=fm)
+    assert load_contract(pack).frozen == {"model": "gpt-x"}
+
+
 def test_discover_skips_underscore_and_non_packs(tmp_path: Path) -> None:
     _make_pack(tmp_path, "real")
     _make_pack(tmp_path, "_template")

--- a/tests/test_zoo_verify.py
+++ b/tests/test_zoo_verify.py
@@ -89,6 +89,20 @@ def test_bad_metric_direction_fails(tmp_path: Path) -> None:
     assert r.status == "fail" and "metric.direction" in r.message
 
 
+def test_frozen_valid_passes_and_surfaces(tmp_path: Path) -> None:
+    c = copy.deepcopy(_CONTRACT)
+    c["frozen"] = {"model": "gpt-x", "budget": "1h"}
+    r = _by_name(verify_pack(_build(tmp_path, contract=c)))["contract"]
+    assert r.status == "pass" and "freeze" in r.message
+
+
+def test_frozen_malformed_fails(tmp_path: Path) -> None:
+    c = copy.deepcopy(_CONTRACT)
+    c["frozen"] = "gpt-x"  # must be a mapping
+    r = _by_name(verify_pack(_build(tmp_path, contract=c)))["contract"]
+    assert r.status == "fail" and "frozen" in r.message
+
+
 # ── sections ──────────────────────────────────────────────────────────────────
 
 def test_missing_readme_section_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Builds the **collection** half of the zoo (`arbor benchmark add`) on top of the scaffolder from #32, plus the optional `frozen:` field on the pack format. Implements the deterministic spine of the design note (`docs/dev/benchmark-add.md`); the agent-driven survey + bring-up are the next sub-phase.

Stacks on #32: rather than duplicating a scaffolder, `collect.py` reuses #32's `scaffold_benchmark()` for its scaffolding stage. The two CLI verbs are complementary — `scaffold` (make a local dir Arbor-ready) and `add` (acquire a remote benchmark, then scaffold).

## Changes

**A — `frozen:` field (the freeze axis).** Optional README front-matter field declaring what a pack holds fixed (`{model}` or `{budget}`), so an improvement is attributable. Loaded by `Contract`; the verifier validates its shape and surfaces it. Documented in `docs/zoo.{md,zh.md}` + the `_template`.

**B — collection spine (`src/zoo/`):**
- `cache.py` — global `~/.arbor/cache/benchmarks/<name>` cache + provenance manifest (`ARBOR_BENCHMARK_CACHE` override).
- `acquire.py` — `Acquirer` protocol + `GitRepoAcquirer` (clone/pin, fully implemented) and `HFDatasetAcquirer` (needs `huggingface_hub`); `select_acquirer`.
- `collect.py` — pipeline: select acquirer → acquire into cache → scaffold a draft via #32's `scaffold_benchmark` → structural verify. Standalone; never wires into the Coordinator/Executor loop (a §2.1 correctness requirement).
- `arbor benchmark add <spec> --name <n>` CLI — acquires + scaffolds a draft and prints the remaining human/agent steps (drafting auto, acceptance human).

**C — docs:** `docs/dev/benchmark-add.md` (full design: positioning, origination — benchmark/direction/work-first + two-layer zoo, the freeze axis, the AutoSOTA guardrail, the staged pipeline) and `docs/dev/benchmark-backlog.md` (researched collectable-benchmark shortlist). Internal dev docs are excluded from the published site.

## What's NOT here (next sub-phase)

The **agent-driven stages** — Stage 0 survey (canonical source / general baseline / angle + frozen substrate) and Stage 2 baseline bring-up — need a live LLM provider. This PR ships the deterministic plumbing they'll plug into; `collect()` takes an unused `provider` arg as the seam.

## Verification

`arbor benchmark add <git-url> --name x` and `arbor benchmark scaffold <dir>` both run end-to-end. ruff + mypy + full suite + `mkdocs build --strict` green. New tests: cache / git-acquire / collect / CLI, plus the `frozen:` field.