### PR TITLE
fix(llm): make Responses API cache hits visible; default example to auto

### DIFF
--- a/examples/algotune_knn/research_config.yaml
+++ b/examples/algotune_knn/research_config.yaml
@@ -33,4 +33,4 @@ executor:
   max_turns: 30
 
 ui:
-  interaction_mode: review   # auto | direction | review | collaborative
+  interaction_mode: auto   # auto | direction | review | collaborative

--- a/src/core/llm/openai_responses.py
+++ b/src/core/llm/openai_responses.py
@@ -392,8 +392,18 @@ class OpenAIResponsesProvider(LLMProvider):
         usage = Usage()
         raw_usage = getattr(raw, "usage", None)
         if raw_usage:
-            usage.input_tokens = int(getattr(raw_usage, "input_tokens", 0) or 0)
+            total_input = int(getattr(raw_usage, "input_tokens", 0) or 0)
             usage.output_tokens = int(getattr(raw_usage, "output_tokens", 0) or 0)
+            # Responses counts cached prompt tokens inside ``input_tokens`` (under
+            # ``input_tokens_details.cached_tokens``); split them out so cache hits
+            # are visible and ``total_input_tokens`` doesn't double-count.
+            details = getattr(raw_usage, "input_tokens_details", None)
+            cached = getattr(details, "cached_tokens", None) if details is not None else None
+            if cached is None and isinstance(details, dict):
+                cached = details.get("cached_tokens")
+            cached = int(cached or 0)
+            usage.input_tokens = max(0, total_input - cached)
+            usage.cache_read_tokens = cached
 
         stop_reason = "tool_use" if tool_calls else "end_turn"
         if getattr(raw, "status", None) == "incomplete":


### PR DESCRIPTION
Two small fixes surfaced while dogfooding algotune_knn end-to-end.

**fix(llm): report Responses API cached_tokens** — `openai_responses` parsed only input/output tokens, so gpt-5.x via the Responses API always logged `cache_read=0` even when the prefix was cached. Now splits `cached_tokens` out of `input_tokens` (mirroring `openai_compat`), so token stats are honest and `total_input_tokens` isn't double-counted. Verified by unit-checking the parse; KV cache itself confirmed ~99% read-hit on the anthropic path.

**docs(examples): default algotune_knn to auto** — `review` hangs an unattended/headless first run waiting for input; `auto` is the right default for a copy-paste run.