### PR TITLE
fix(llm): make logprobs opt-in (default off)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -292,6 +292,7 @@ See [Plugins](plugins.md) and [Skills](skills.md).
 | `executor_max_turns` | Hard cap on a single experiment's reasoning turns — a runaway/cost safety valve. Override with `--max-turns`. |
 | `reasoning_effort` | How hard the model thinks per step (`low`/`medium`/`high`, where the provider supports it). |
 | `meta_model` | Optional cheaper/faster model for meta-level steps (distilling insight, drafting the report) while `model` drives the main loop. |
+| `logprobs` | Opt-in sampled-token logprobs for token-faithful trajectory traces. Off by default — some OpenAI-compatible endpoints (Gemini, Ollama) reject the field with HTTP 400 instead of ignoring it. Enable only where supported (OpenAI, vLLM, DeepSeek). Override with `--logprobs`/`--no-logprobs`. |
 
 ### Budgets and timeouts
 

--- a/docs/configuration.zh.md
+++ b/docs/configuration.zh.md
@@ -253,6 +253,7 @@ arbor run --max-cycles 20 --mode review --no-webui
 | `executor_max_turns` | 单个实验推理轮次的硬上限——一个失控/成本安全阀。用 `--max-turns` 覆盖。 |
 | `reasoning_effort` | 模型每步的思考投入程度（`low`/`medium`/`high`，在 provider 支持处）。 |
 | `meta_model` | 可选的、更便宜/更快的模型，用于元层级步骤（提炼洞见、起草报告），而 `model` 驱动主循环。 |
+| `logprobs` | 可选的采样 token logprobs，用于 token 忠实的轨迹记录。默认关闭——部分 OpenAI 兼容端点（Gemini、Ollama）会以 HTTP 400 拒绝该字段而非忽略它。仅在支持的端点（OpenAI、vLLM、DeepSeek）上启用。可用 `--logprobs`/`--no-logprobs` 覆盖。 |
 
 ### 预算与超时 { #budgets-and-timeouts }
 

--- a/examples/research_config.example.yaml
+++ b/examples/research_config.example.yaml
@@ -24,6 +24,11 @@ llm:
   #                                    # or paste the key here / pass --api-key
   # base_url:                          # set for proxies / vLLM / Ollama
   reasoning_effort: high               # low | medium | high | none
+  # logprobs: false                    # opt-in sampled-token logprobs for
+  #                                    # token-faithful trajectory traces. Off
+  #                                    # by default — Gemini/Ollama reject the
+  #                                    # field with HTTP 400; enable only where
+  #                                    # supported (OpenAI, vLLM, DeepSeek).
 
   # meta_model:                        # optional: a different model for the
   #                                    # orchestrator than for executors

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -151,6 +151,7 @@ def create_provider(config: AgentConfig) -> LLMProvider:
             base_url=config.base_url,
             max_retries=config.llm_provider_retries,
             timeout=config.llm_timeout,
+            logprobs=config.logprobs,
         )
     # backend == "litellm": unified transport for the chat-completions family
     # (DeepSeek/Qwen/Gemini/OpenAI-compatible proxies). Reasoning chain is
@@ -164,4 +165,5 @@ def create_provider(config: AgentConfig) -> LLMProvider:
         max_retries=config.llm_provider_retries,
         timeout=config.llm_timeout,
         reasoning_effort=config.reasoning_effort,
+        logprobs=config.logprobs,
     )

--- a/src/core/config_cli.py
+++ b/src/core/config_cli.py
@@ -55,6 +55,7 @@ LLM_FLAGS: tuple[CLIField, ...] = (
     CLIField("--parallel-tool-calls", "parallel_tool_calls", None, "Allow GPT Responses models to request multiple tools in one turn", bool_optional=True),
     CLIField("--thinking-budget-tokens", "thinking_budget_tokens", int, "Claude extended-thinking token budget override"),
     CLIField("--max-tokens", "max_tokens", int, "Max output tokens per LLM call (default: 16384)"),
+    CLIField("--logprobs", "logprobs", None, "Request sampled-token logprobs for trajectory traces (default: off; Gemini/Ollama reject it)", bool_optional=True),
     CLIField("--llm-timeout", "llm_timeout", float, "HTTP timeout per LLM API call (default: 300)"),
     CLIField("--llm-provider-retries", "llm_provider_retries", int, "Native SDK retries per LLM API call (default: 3)"),
     CLIField("--llm-retry-attempts", "llm_retry_attempts", int, "Agent-level retry attempts for transient LLM errors (default: 5)"),

--- a/src/core/config_schema.py
+++ b/src/core/config_schema.py
@@ -151,6 +151,10 @@ class LLMConfig(BaseModel):
     parallel_tool_calls: bool | None = True
     thinking_budget_tokens: int | None = None
     max_tokens: int = 16384
+    # Opt-in: request sampled-token logprobs for token-faithful trajectory traces.
+    # Off by default — some OpenAI-compatible endpoints (Gemini, Ollama) reject the
+    # field with HTTP 400 instead of ignoring it; enable only where supported.
+    logprobs: bool = False
     llm_timeout: float = 300.0
     llm_provider_retries: int = 3
     llm_retry_attempts: int = 5

--- a/src/core/llm/litellm_provider.py
+++ b/src/core/llm/litellm_provider.py
@@ -38,6 +38,7 @@ class LiteLLMProvider(OpenAICompatProvider):
         max_retries: int = 3,
         timeout: float = 300.0,
         reasoning_effort: str | None = "high",
+        logprobs: bool = False,
     ):
         import litellm
 
@@ -53,6 +54,7 @@ class LiteLLMProvider(OpenAICompatProvider):
         self.timeout = timeout
         self.max_retries = max_retries
         self.reasoning_effort = reasoning_effort
+        self.logprobs = logprobs
         # No AsyncOpenAI client — litellm.acompletion is the transport.
         try:
             self._enc = tiktoken.encoding_for_model(model)

--- a/src/core/llm/openai_compat.py
+++ b/src/core/llm/openai_compat.py
@@ -80,10 +80,12 @@ class OpenAICompatProvider(LLMProvider):
         base_url: str | None = None,
         max_retries: int = 3,
         timeout: float = 300.0,
+        logprobs: bool = False,
     ):
         self.model = model
         self.base_url = base_url
         self.timeout = timeout
+        self.logprobs = logprobs
         self._client = AsyncOpenAI(
             api_key=api_key or os.environ.get("OPENAI_API_KEY", "dummy"),
             base_url=base_url,
@@ -123,10 +125,13 @@ class OpenAICompatProvider(LLMProvider):
             "model": self.model,
             "messages": oai_messages,
             "max_tokens": max_tokens,
-            # Token-faithful traces: ask for sampled-token logprobs. Endpoints that
-            # don't support it ignore these; we read back None and degrade cleanly.
-            "logprobs": True,
         }
+        # Token-faithful traces: ask for sampled-token logprobs when enabled. Opt-in
+        # — some OpenAI-compatible endpoints (Gemini, Ollama) reject the field with
+        # HTTP 400 instead of ignoring it. _extract_logprobs degrades to None when
+        # the endpoint returns none.
+        if self.logprobs:
+            params["logprobs"] = True
         if oai_tools:
             params["tools"] = oai_tools
             params["tool_choice"] = "auto"

--- a/tests/test_openai_compat_logprobs.py
+++ b/tests/test_openai_compat_logprobs.py
@@ -1,0 +1,112 @@
+"""logprobs must be opt-in — sending it unconditionally 400s on Gemini/Ollama.
+
+Regression for ``OpenAICompatProvider.create()``: the ``logprobs`` request param
+is added only when the provider was constructed with ``logprobs=True``. Sending
+it unconditionally broke every OpenAI-compatible endpoint that rejects unknown
+fields instead of ignoring them (Gemini's ``/v1beta/openai/`` layer returns
+``400 Unknown name "logprobs"``; Ollama behaves similarly). The LiteLLM backend
+inherits the same gate via the shared ``create()``.
+
+Self-contained: run directly with any Python 3.10+ that can import ``arbor``
+(``python tests/test_openai_compat_logprobs.py``) or collect with pytest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parent.parent
+if "arbor" not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(
+        "arbor", _ROOT / "src" / "__init__.py",
+        submodule_search_locations=[str(_ROOT / "src")],
+    )
+    assert _spec and _spec.loader
+    _arbor = importlib.util.module_from_spec(_spec)
+    sys.modules["arbor"] = _arbor
+    _spec.loader.exec_module(_arbor)
+
+from arbor.core.llm.openai_compat import OpenAICompatProvider  # noqa: E402
+
+
+def _fake_raw() -> SimpleNamespace:
+    """Minimal chat-completions response that _parse_response can consume."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=None),
+                logprobs=None,
+            )
+        ],
+        usage=None,
+        model="test-model",
+    )
+
+
+def _capturing_provider(**kwargs: Any) -> tuple[OpenAICompatProvider, dict[str, Any]]:
+    """Provider whose _acompletion records the params it was called with."""
+    provider = OpenAICompatProvider(model="test-model", api_key="dummy", **kwargs)
+    captured: dict[str, Any] = {}
+
+    async def _capture(**params: Any) -> Any:
+        captured.update(params)
+        return _fake_raw()
+
+    provider._acompletion = _capture  # type: ignore[assignment]
+    return provider, captured
+
+
+def test_logprobs_defaults_off_in_config() -> None:
+    from arbor.core.config_schema import LLMConfig
+
+    assert LLMConfig().logprobs is False
+    assert LLMConfig(logprobs=True).logprobs is True
+
+
+def test_logprobs_not_sent_by_default() -> None:
+    provider, captured = _capturing_provider()
+    asyncio.run(provider.create(system="s", messages=[{"role": "user", "content": "hi"}]))
+    assert "logprobs" not in captured, f"expected no logprobs, got: {captured}"
+
+
+def test_logprobs_sent_when_enabled() -> None:
+    provider, captured = _capturing_provider(logprobs=True)
+    asyncio.run(provider.create(system="s", messages=[{"role": "user", "content": "hi"}]))
+    assert captured.get("logprobs") is True
+
+
+def test_litellm_provider_inherits_gate() -> None:
+    """LiteLLMProvider subclasses OpenAICompatProvider and shares create(); its
+    logprobs attribute must default off and be settable via the constructor."""
+    from arbor.core.llm.litellm_provider import LiteLLMProvider
+
+    assert LiteLLMProvider(model="gpt-4o", api_key="dummy").logprobs is False
+    assert LiteLLMProvider(model="gpt-4o", api_key="dummy", logprobs=True).logprobs is True
+
+
+def test_create_provider_plumbs_logprobs() -> None:
+    """create_provider must forward config.logprobs to the constructed provider."""
+    from arbor.core import create_provider
+
+    base = dict(
+        provider="openai-chat", openai_api="chat", model="m", api_key="k",
+        base_url=None, llm_provider_retries=1, llm_timeout=10.0,
+        reasoning_effort="high",
+    )
+    off = create_provider(SimpleNamespace(**base, logprobs=False))
+    on = create_provider(SimpleNamespace(**base, logprobs=True))
+    assert off.logprobs is False
+    assert on.logprobs is True
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for t in tests:
+        t()
+        print(f"ok  {t.__name__}")
+    print(f"\n{len(tests)} passed")


### PR DESCRIPTION
## Summary

`OpenAICompatProvider.create()` sent `"logprobs": True` on every chat-completions call, assuming unsupported endpoints ignore the field. They don't — Gemini's OpenAI-compat layer and Ollama reject it with HTTP 400, leaving Arbor stuck in intake ("model unavailable") on turn 1. The `litellm` backend inherits the same `create()` and `litellm.drop_params` doesn't help (litellm considers `logprobs` a supported param for `gemini/*`, so it isn't stripped).

This gates `logprobs` behind a new **opt-in** `llm.logprobs` config field (default `false`), plumbed through `create_provider` to both `OpenAICompatProvider` and `LiteLLMProvider`. A generic OpenAI-compatible provider cannot assume the endpoint supports logprobs, so off-by-default makes every listed backend (DeepSeek / Qwen / GLM / vLLM / Ollama / Gemini) work out of the box. `_extract_logprobs` already degrades to `None`, so token-faithful traces (#41) simply skip when off — users who need them set `llm.logprobs: true` (OpenAI / vLLM / DeepSeek).

## Linked issue

Closes #49

## Type of change

- [x] 🐞 Bug fix (`fix`)

## How was this tested?

```text
$ python tests/test_openai_compat_logprobs.py
ok  test_create_provider_plumbs_logprobs
ok  test_litellm_provider_inherits_gate
ok  test_logprobs_defaults_off_in_config
ok  test_logprobs_not_sent_by_default
ok  test_logprobs_sent_when_enabled
5 passed

$ python -m pytest tests/ -q
........ [full suite green, 3 pre-existing skips]
```

End-to-end against the real Gemini `/v1beta/openai/` endpoint with the cloned source:
- default config (`logprobs` off) → `OK`, `logprobs=None` ✅
- `logprobs=true` → reproduces the exact `400 Unknown name "logprobs"` ✅ (gate is real)

## Checklist

- [x] PR title follows Conventional Commits (`fix(llm): ...`).
- [x] The change is focused and reasonably small (9 files, +136/−3).
- [x] I ran the relevant tests locally and they pass.
- [x] Docs / examples updated (`docs/configuration.md`, `docs/configuration.zh.md`, `examples/research_config.example.yaml`). The READMEs don't enumerate per-field `llm:` options (they point to `docs/configuration.md`), so no README change was needed.
- [x] No secrets, API keys, or tokens are included in the diff.