### PR TITLE
feat(docker): security-hardened container with MCP default mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the image build context lean. `pip install` needs pyproject.toml + src/;
+# docker/entrypoint.sh is COPYed separately. Everything else is excluded.
+.git
+.github
+.venv
+venv
+env
+__pycache__
+**/__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+dist
+build
+*.egg-info
+tests
+docs
+arbor-zoo
+node_modules
+.env
+.env.*
+.DS_Store
+*.md
+!docker/README.md
+# Test fixtures/script — not needed in the image (kept out of the build context).
+docker/test_mcp.py
+docker/test-bench

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ research_sessions/
 # Project page build output
 project_page/node_modules/
 project_page/dist/
+
+# Docker local config (docker-compose.yml .env)
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# syntax=docker/dockerfile:1.7
+#
+# Arbor — security-hardened container. Default mode: MCP over stdio.
+#
+# Build from the repo root:   docker build -t arbor .
+# Or via compose:             docker compose build   (then see docker-compose.yml)
+# MCP (default, stdio):       docker compose run --rm arbor
+# Web monitor:                ARBOR_MODE=web ARBOR_SESSION=… docker compose up
+
+FROM python:3.12-slim
+
+# ── unprivileged user (the container never runs as root) ───────────────────
+ARG ARBOR_UID=1000
+ARG ARBOR_GID=1000
+# The host GID (e.g. macOS 20=dialout) can collide with an existing Debian group,
+# so reuse it instead of trying to create it.
+RUN if ! getent group "${ARBOR_GID}" >/dev/null; then groupadd --gid "${ARBOR_GID}" arbor; fi \
+ && useradd --uid "${ARBOR_UID}" --gid "${ARBOR_GID}" --create-home --shell /bin/sh arbor
+
+# ── runtime deps ───────────────────────────────────────────────────────────
+# git   — worktree isolation for `arbor run` (and a `doctor` check)
+# tini  — PID 1: reaps zombies, forwards INT/TERM cleanly
+# socat — re-exposes `arbor web` (binds 127.0.0.1 only) on 0.0.0.0 without
+#         resorting to host networking (preserves network isolation)
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git ca-certificates tini socat \
+ && rm -rf /var/lib/apt/lists/*
+
+# ── install Arbor from the repo source + the MCP SDK ───────────────────────
+# The default mode is `arbor mcp` (stdio); the MCP SDK is the project's optional
+# `[mcp]` extra (pyproject.toml). `.dockerignore` keeps this context lean.
+COPY . /srv/arbor
+RUN pip install --no-cache-dir "/srv/arbor[mcp]"
+
+# ── environment ────────────────────────────────────────────────────────────
+ENV HOME=/home/arbor \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    ARBOR_MODE=mcp
+
+WORKDIR /workspace
+
+COPY docker/entrypoint.sh /usr/local/bin/arbor-entrypoint
+RUN chmod 0755 /usr/local/bin/arbor-entrypoint
+
+# Drop privileges; tini re-execs the entrypoint as PID 1.
+USER arbor
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/arbor-entrypoint"]
+# Extra args forwarded to the subcommand (e.g. `run --rm arbor --help`).
+CMD []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+# Arbor — security-hardened container. Default mode: MCP (stdio).
+# Select modes with ARBOR_MODE (see docker/.env.example). MCP/doctor/version/...
+# are one-shots (`docker compose run --rm arbor`); `web` is long-running (`up`).
+services:
+  arbor:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        ARBOR_UID: ${ARBOR_UID:-1000}
+        ARBOR_GID: ${ARBOR_GID:-1000}
+    image: arbor:hardened
+    # Run as the build-time user (matches host uid so the workspace mount is
+    # writable). Override via .env if your host uid differs.
+    user: "${ARBOR_UID:-1000}:${ARBOR_GID:-1000}"
+
+    # MCP is stdio — stdin must be attachable: `docker compose run --rm arbor`.
+    stdin_open: true
+    tty: true
+
+    environment:
+      ARBOR_MODE: ${ARBOR_MODE:-mcp}
+      ARBOR_PROVIDER: ${ARBOR_PROVIDER:-}
+      ARBOR_MODEL: ${ARBOR_MODEL:-}
+      ARBOR_BASE_URL: ${ARBOR_BASE_URL:-}
+      ARBOR_API_KEY: ${ARBOR_API_KEY:-}
+      ARBOR_CWD: ${ARBOR_CWD:-/workspace}
+      ARBOR_SESSION: ${ARBOR_SESSION:-}
+      WEB_PORT: ${WEB_PORT:-8765}
+      # git identity for `arbor run` worktree commits (non-interactive).
+      GIT_AUTHOR_NAME: ${GIT_AUTHOR_NAME:-Arbor}
+      GIT_AUTHOR_EMAIL: ${GIT_AUTHOR_EMAIL:-arbor@localhost}
+      GIT_COMMITTER_NAME: ${GIT_COMMITTER_NAME:-Arbor}
+      GIT_COMMITTER_EMAIL: ${GIT_COMMITTER_EMAIL:-arbor@localhost}
+
+    volumes:
+      # Project dir — the only persistent, host-backed mount.
+      - ${ARBOR_WORKSPACE:-./workspace}:/workspace
+
+    # ── security hardening ────────────────────────────────────────────────
+    read_only: true               # rootfs immutable; only the mounts below are writable
+    tmpfs:
+      # Ephemeral in-RAM home: config + caches. The API key written by
+      # `arbor config init` lives in RAM and never reaches disk. uid/gid must
+      # match the runtime user or the dir is root-owned and unwritable.
+      - /home/arbor:uid=${ARBOR_UID:-1000},gid=${ARBOR_GID:-1000},mode=0700,size=64m
+      - /tmp:mode=1777,size=128m
+    security_opt:
+      - no-new-privileges:true    # blocks setuid escalation
+    cap_drop:
+      - ALL                       # no Linux capabilities
+    networks:
+      - arbor-net
+    ports:
+      # Used only in ARBOR_MODE=web; a no-op otherwise (nothing listens).
+      - "${WEB_PORT:-8765}:${WEB_PORT:-8765}"
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+          cpus: "2.0"
+
+networks:
+  arbor-net:
+    driver: bridge

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -1,0 +1,32 @@
+# Copy to .env (next to docker-compose.yml) and edit.
+# NEVER commit .env — it holds your API key.
+#   cp docker/.env.example .env
+
+# ── Arbor mode (default: mcp) ──────────────────────────────────────────────
+#   mcp | run | web | doctor | version | config | replay | report | export |
+#   idea-check | quickstart | benchmark | setup | install | uninstall | login
+ARBOR_MODE=mcp
+
+# ── LLM provider — generated into ~/.arbor/config.yaml at startup ──────────
+# (only if no config is mounted; the key stays in RAM via the tmpfs home)
+ARBOR_PROVIDER=openai-chat
+ARBOR_MODEL=gemini-2.5-flash
+ARBOR_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai/
+ARBOR_API_KEY=replace-with-your-key
+
+# ── Workspace (host dir mounted at /workspace) ─────────────────────────────
+ARBOR_WORKSPACE=./workspace
+
+# ── web mode only ──────────────────────────────────────────────────────────
+# ARBOR_SESSION=my-run-name   # required for web; session under .arbor/sessions/
+WEB_PORT=8765
+
+# ── run mode ───────────────────────────────────────────────────────────────
+ARBOR_CWD=/workspace
+
+# ── uid/gid ────────────────────────────────────────────────────────────────
+# Match your host uid/gid so the workspace mount is writable by the container.
+#   macOS:   ARBOR_UID=$(id -u)  ARBOR_GID=$(id -g)   (often 501 / 20)
+#   Linux:   usually 1000 / 1000
+ARBOR_UID=1000
+ARBOR_GID=1000

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,84 @@
+# Running Arbor in Docker
+
+A security-hardened container image. Default mode is **MCP over stdio**; every
+`arbor` subcommand is selectable via the `ARBOR_MODE` env var.
+
+## Security posture
+
+| Measure | How |
+|---|---|
+| Non-root | Image builds an `arbor` user; compose runs as `user: <uid>:<gid>` |
+| Immutable rootfs | `read_only: true` — only the mounts below are writable |
+| Secrets in RAM only | `~/.arbor` is tmpfs; the API key written by `config init` never touches disk |
+| No capabilities | `cap_drop: [ALL]` |
+| No escalation | `security_opt: [no-new-privileges:true]` |
+| Resource caps | `memory: 2g`, `cpus: 2.0` (tune in `.env`) |
+| Isolated network | custom `arbor-net` bridge (no host networking) |
+| PID 1 hygiene | `tini` reaps zombies and forwards signals |
+
+## Quick start
+
+```bash
+cp docker/.env.example .env
+# edit .env: set ARBOR_API_KEY and ARBOR_UID/ARBOR_GID (run `id -u` / `id -g`)
+mkdir -p workspace
+
+docker compose build
+```
+
+### MCP (default) — stdio, driven by an MCP client
+
+```bash
+docker compose run --rm arbor          # stdin attached; speaks MCP over stdio
+```
+
+Point an MCP client (e.g. Claude Code) at:
+```json
+{ "mcpServers": { "arbor": { "command": "docker", "args": ["compose", "-f", "/abs/path/to/Arbor/docker-compose.yml", "run", "--rm", "arbor"] } } }
+```
+
+### Other modes
+
+```bash
+# doctor / version — one-shot
+ARBOR_MODE=doctor docker compose run --rm arbor
+ARBOR_MODE=version docker compose run --rm arbor
+
+# run — research session (needs a git repo in ./workspace)
+ARBOR_MODE=run docker compose run --rm arbor --yes "improve accuracy" --yes-cwd /workspace
+
+# web — read-only monitor (long-running, exposes WEB_PORT)
+ARBOR_MODE=web ARBOR_SESSION=my-run docker compose up
+# → http://localhost:8765
+```
+
+## Mode reference
+
+| `ARBOR_MODE` | Invocation | Notes |
+|---|---|---|
+| `mcp` *(default)* | `run --rm arbor` | stdio; the MCP client spawns it |
+| `run` | `run --rm arbor [args]` | research session; workspace must be a git repo |
+| `web` | `up` | needs `ARBOR_SESSION`; serves `WEB_PORT` |
+| `doctor` | `run --rm arbor` | checks PATH, git, API keys |
+| `version` | `run --rm arbor` | |
+| `config` | `run --rm arbor show` | `show` / `init` via extra args |
+| `replay`/`report`/`export` | `run --rm arbor <session> [args]` | operate on a past session |
+| `idea-check`/`quickstart`/`benchmark`/`setup`/`install`/`uninstall`/`login` | `run --rm arbor [args]` | pass subcommand args |
+
+Extra args after the mode are forwarded to `arbor <mode>`.
+
+## Notes
+
+- **UID matching.** The workspace bind mount must be writable by the container
+  user. Set `ARBOR_UID`/`ARBOR_GID` in `.env` to your host uid/gid (`id -u`/`id -g`).
+  The host GID (e.g. macOS 20) is reused if it already exists in the image.
+- **`arbor run` may need a writable site-packages** (if an experiment does
+  `pip install`). The rootfs is read-only by default; either let the project
+  install with `--user` (writes to the tmpfs home) or relax with a
+  `docker-compose.override.yml` setting `read_only: false`.
+- **`arbor web` binds 127.0.0.1.** The entrypoint runs `socat` to re-expose it on
+  `0.0.0.0:${WEB_PORT}` so the host-mapped port works — no host networking needed.
+- **Config from env.** If `~/.arbor/config.yaml` is absent and `ARBOR_PROVIDER`
+  is set, the entrypoint runs `arbor config init` to generate it from env vars
+  (key included). To use a pre-built config instead, mount it over
+  `/home/arbor/.arbor/config.yaml`.

--- a/docker/TESTING.md
+++ b/docker/TESTING.md
@@ -1,0 +1,74 @@
+# Testing the Docker image
+
+`docker/test_mcp.py` is a self-contained integration test that verifies the
+containerized arbor MCP server end-to-end. It spawns the container as a
+subprocess, speaks MCP over stdio, and drives the full research-loop primitive
+set (tree, eval, worktree, merge, prune, report, dashboard) with assertions.
+
+## Prerequisites
+
+```bash
+docker compose build          # from the repo root
+```
+
+The test uses a **dummy API key** — none of the MCP tools in the loop call the
+LLM (`eval_run` runs your `eval.py`; `generate_report` renders from durable
+artifacts). So no provider credentials are needed.
+
+## Run
+
+```bash
+python docker/test_mcp.py
+```
+
+Expected: `14/14 checks passed`.
+
+## What it verifies
+
+The test builds a throwaway toy benchmark under `/tmp/arbor-mcp-test-ws/`,
+mounts it into the container as `/workspace`, and runs three use cases:
+
+### UC1 — baseline eval
+Sets session metadata (`eval_cmd`, `metric_direction`, `trunk_branch`), runs the
+baseline eval on dev and test splits, and confirms the tree records
+`baseline=19`. Tools: `tree_set_meta`, `eval_run`, `tree_view`.
+
+### UC2 — hypothesis → experiment → merge
+Adds a hypothesis node, creates an isolated git worktree, edits `LEARNING_RATE`
+to `0.1` (the peak), evals the experiment (score 100), then merges the
+experiment branch into `trunk` — after a dry-run guard check. Tools:
+`tree_add_node`, `worktree_create`, `eval_run`, `git_merge_branch`,
+`tree_update_node`.
+
+### UC3 — bad hypothesis → prune → report → dashboard
+Adds an overshoot hypothesis (`LR=1.0`, score −8000), evals it, prunes it,
+generates `REPORT.md`, and opens the read-only dashboard. Tools: `tree_prune`,
+`generate_report`, `open_dashboard`.
+
+## The fixture
+
+`docker/test-bench/` holds the toy benchmark the test copies into the workspace:
+
+- `solution.py` — the edit surface. `solve()` returns a deterministic score that
+  peaks at `LEARNING_RATE=0.1` (baseline `0.01` → 19, peak `0.1` → 100,
+  overshoot `1.0` → −8000).
+- `eval.py` — protected harness printing `score: <float>` (the contract
+  `eval_run` parses).
+
+## Merge isolation (safety)
+
+**No real repository is touched.** All git operations — worktrees, commits,
+merges — happen inside the throwaway toy repo at `/tmp/arbor-mcp-test-ws/test-bench`.
+Merges target only its non-protected `trunk` branch (arbor refuses to merge into
+the protected `main`). The workspace and the container are removed in a
+`finally` block when the test exits.
+
+## CI
+
+The test is plain Python (no pytest dependency) and exits non-zero on any
+failed assertion, so it can run as a single step:
+
+```yaml
+- run: docker compose build
+- run: python docker/test_mcp.py
+```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Arbor entrypoint: generate ~/.arbor/config.yaml from env (if absent), then
+# dispatch on ARBOR_MODE (default: mcp). Extra CMD args are forwarded to the
+# subcommand as "$@".
+set -eu
+
+CONFIG_DIR="${HOME}/.arbor"
+CONFIG_FILE="${CONFIG_DIR}/config.yaml"
+mkdir -p "$CONFIG_DIR"
+
+# Build the config from env vars. Wrapped in a function so the `set --` used to
+# assemble args does not clobber the script's own "$@" (CMD args). POSIX sh
+# gives each function its own positional parameters.
+gen_config() {
+    set -- --force --provider "$ARBOR_PROVIDER"
+    [ -n "${ARBOR_MODEL:-}" ]    && set -- "$@" --model "$ARBOR_MODEL"
+    [ -n "${ARBOR_BASE_URL:-}" ] && set -- "$@" --base-url "$ARBOR_BASE_URL"
+    [ -n "${ARBOR_API_KEY:-}" ]  && set -- "$@" --api-key "$ARBOR_API_KEY"
+    arbor config init "$@"
+}
+
+# The home dir is tmpfs in compose, so any key written here lives in RAM only.
+# Redirect config-init's stdout to stderr: `arbor config init` echoes the config
+# to stdout, which would corrupt the MCP JSON-RPC stream (MCP owns stdout).
+if [ ! -f "$CONFIG_FILE" ] && [ -n "${ARBOR_PROVIDER:-}" ]; then
+    gen_config 1>&2
+elif [ ! -f "$CONFIG_FILE" ]; then
+    echo "arbor: no config at $CONFIG_FILE and ARBOR_PROVIDER is unset." >&2
+    echo "       Set ARBOR_PROVIDER/ARBOR_MODEL/ARBOR_API_KEY or mount a config." >&2
+fi
+
+mode="${ARBOR_MODE:-mcp}"
+
+case "$mode" in
+    mcp)
+        # stdio transport — an MCP client drives this as a one-shot process.
+        exec arbor mcp "$@"
+        ;;
+    web)
+        # `arbor web` binds 127.0.0.1 only (src/webui/server.py). socat re-exposes
+        # it on 0.0.0.0:${WEB_PORT} so the host-mapped port is reachable, without
+        # weakening isolation with host networking.
+        : "${ARBOR_SESSION:=}"
+        : "${WEB_PORT:=8765}"
+        : "${WEB_INTERNAL_PORT:=12765}"
+        : "${ARBOR_CWD:=/workspace}"
+        if [ -z "$ARBOR_SESSION" ]; then
+            echo "arbor web: ARBOR_SESSION (session name) is required." >&2
+            exit 2
+        fi
+        arbor web --no-open --port "$WEB_INTERNAL_PORT" --cwd "$ARBOR_CWD" "$ARBOR_SESSION" &
+        webpid=$!
+        socat TCP-LISTEN:"$WEB_PORT",fork,reuseaddr,bind=0.0.0.0 \
+              TCP4:127.0.0.1:"$WEB_INTERNAL_PORT" &
+        socatpid=$!
+        trap 'kill "$webpid" "$socatpid" 2>/dev/null || true; exit 0' INT TERM
+        echo "arbor web: read-only monitor on 0.0.0.0:${WEB_PORT} (session: ${ARBOR_SESSION})" >&2
+        wait "$webpid"
+        ;;
+    run|doctor|version|quickstart|idea-check|benchmark|replay|export|report|setup|config|login|install|uninstall)
+        exec arbor "$mode" "$@"
+        ;;
+    *)
+        echo "arbor: unknown ARBOR_MODE='$mode'." >&2
+        echo "       expected: mcp|run|web|doctor|version|config|replay|report|export|idea-check|quickstart|benchmark|setup|install|uninstall|login" >&2
+        exec arbor --help
+        ;;
+esac

--- a/docker/test-bench/eval.py
+++ b/docker/test-bench/eval.py
@@ -1,0 +1,25 @@
+"""eval.py — PROTECTED evaluation harness (toy benchmark fixture).
+
+Prints exactly one line ``score: <float>`` for ``--split dev|test``. This is
+the contract arbor's eval_run parses. dev/test are identical here (the objective
+is deterministic), satisfying the disjoint-split requirement trivially.
+"""
+from __future__ import annotations
+
+import argparse
+
+import solution
+
+
+def evaluate(split: str) -> float:
+    return float(solution.solve())
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--split", choices=["dev", "test"], default="dev")
+    print(f"score: {evaluate(p.parse_args().split):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/test-bench/solution.py
+++ b/docker/test-bench/solution.py
@@ -1,0 +1,14 @@
+"""solution.py — the edit surface (toy benchmark fixture for docker/test_mcp.py).
+
+The score is a deterministic parabola of LEARNING_RATE peaking at 0.1:
+  LR=0.01 -> 19   (baseline)
+  LR=0.1  -> 100  (peak; the "good" hypothesis)
+  LR=1.0  -> -8000 (overshoot; the "bad" hypothesis to prune)
+"""
+from __future__ import annotations
+
+LEARNING_RATE = 0.01  # baseline
+
+
+def solve() -> float:
+    return round(-(LEARNING_RATE - 0.1) ** 2 * 10000 + 100, 4)

--- a/docker/test_mcp.py
+++ b/docker/test_mcp.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Integration test for the containerized arbor MCP server.
+
+Spawns the container as a subprocess, speaks MCP over stdio, and drives 3 use
+cases (baseline eval → experiment+merge → prune+report) with assertions.
+
+Self-contained: builds a throwaway toy benchmark under /tmp, uses a dummy API
+key (no tool in the loop calls the LLM), and tears everything down at the end.
+ALL git operations (worktrees, commits, merges) are scoped to the toy repo at
+<workspace>/test-bench; merges target only its non-protected ``trunk`` branch —
+no real repository is ever touched.
+
+Prereq: ``docker compose build`` (from the repo root).
+Run:     ``python docker/test_mcp.py``
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import queue
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+COMPOSE = REPO / "docker-compose.yml"
+FIXTURE = REPO / "docker" / "test-bench"
+CTR = "arbor-mcp-test"
+WS = Path("/tmp/arbor-mcp-test-ws")
+CWD = "/workspace/test-bench"  # in-container path (WS is mounted at /workspace)
+
+
+class MCP:
+    """Minimal MCP stdio client: spawns the container, parses JSON-RPC over its
+    stdout with a streaming decoder (robust to the SDK's keepalive spaces)."""
+
+    def __init__(self, cmd: list[str], env: dict[str, str]):
+        self.p = subprocess.Popen(cmd, stdin=subprocess.PIPE,
+                                  stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                                  env=env, bufsize=-1)
+        self.q: queue.Queue = queue.Queue()
+        threading.Thread(target=self._reader, daemon=True).start()
+        self._id = 0
+
+    def _reader(self) -> None:
+        buf = b""
+        dec = json.JSONDecoder()
+        while True:
+            chunk = self.p.stdout.read1(4096)  # type: ignore[union-attr]
+            if not chunk:
+                break
+            buf += chunk
+            s = buf.decode("utf-8", "replace")
+            i = 0
+            while i < len(s):
+                while i < len(s) and s[i] in " \t\r\n\x00":  # skip keepalive
+                    i += 1
+                if i >= len(s):
+                    break
+                try:
+                    obj, i = dec.raw_decode(s, i)
+                    self.q.put(obj)
+                except json.JSONDecodeError:
+                    break
+            buf = s[i:].encode()
+
+    def call(self, method: str, params: dict | None = None, timeout: int = 60) -> dict:
+        self._id += 1
+        mid = self._id
+        msg = {"jsonrpc": "2.0", "id": mid, "method": method}
+        if params is not None:
+            msg["params"] = params
+        self.p.stdin.write((json.dumps(msg) + "\n").encode())  # type: ignore[union-attr]
+        self.p.stdin.flush()  # type: ignore[union-attr]
+        end = time.time() + timeout
+        while time.time() < end:
+            try:
+                obj = self.q.get(timeout=1)
+            except queue.Empty:
+                continue
+            if obj.get("id") == mid:
+                return obj
+        raise TimeoutError(f"no response for {method} id={mid}")
+
+    def notify(self, method: str, params: dict | None = None) -> None:
+        msg = {"jsonrpc": "2.0", "method": method}
+        if params:
+            msg["params"] = params
+        self.p.stdin.write((json.dumps(msg) + "\n").encode())  # type: ignore[union-attr]
+        self.p.stdin.flush()  # type: ignore[union-attr]
+
+    def tool(self, name: str, args: dict, timeout: int = 60) -> dict:
+        r = self.call("tools/call", {"name": name, "arguments": args}, timeout)
+        res = r.get("result", r)
+        if res.get("isError"):
+            raise RuntimeError(f"{name}: {res['content'][0]['text']}")
+        sc = res.get("structuredContent")
+        if sc:
+            return sc
+        txt = res["content"][0]["text"]
+        try:
+            return json.loads(txt)
+        except Exception:
+            return {"text": txt}
+
+    def close(self) -> None:
+        for _ in range(2):
+            try:
+                self.p.stdin.close()  # type: ignore[union-attr]
+            except Exception:
+                pass
+        try:
+            self.p.wait(timeout=5)
+        except Exception:
+            self.p.kill()
+
+
+def exec_ctr(cmd: str) -> tuple[int, str, str]:
+    r = subprocess.run(["docker", "exec", CTR, "sh", "-c", cmd],
+                       capture_output=True, text=True, timeout=30)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def setup_workspace() -> None:
+    if WS.exists():
+        shutil.rmtree(WS)
+    tb = WS / "test-bench"
+    shutil.copytree(FIXTURE, tb)
+    g = lambda *a: subprocess.run(a, cwd=tb, check=True,
+                                  capture_output=True, text=True)
+    g("git", "init", "-q")
+    g("git", "add", "-A")
+    g("git", "-c", "user.email=t@t.t", "-c", "user.name=T", "commit", "-qm", "baseline")
+    g("git", "branch", "-M", "main")
+    g("git", "branch", "trunk", "main")  # non-protected target for merges
+
+
+def main() -> int:
+    setup_workspace()
+    env = os.environ.copy()
+    env.update(ARBOR_WORKSPACE=str(WS),
+               ARBOR_UID=str(os.getuid()), ARBOR_GID=str(os.getgid()),
+               ARBOR_PROVIDER="openai-chat", ARBOR_MODEL="test",
+               ARBOR_API_KEY="dummy")
+    subprocess.run(["docker", "rm", "-f", CTR], capture_output=True)
+
+    cmd = ["docker", "compose", "-f", str(COMPOSE), "run", "--rm", "--name", CTR, "-T", "arbor"]
+    m = MCP(cmd, env)
+    try:
+        init = m.call("initialize", {"protocolVersion": "2024-11-05", "capabilities": {},
+                                     "clientInfo": {"name": "test", "version": "1.0"}})
+        si = init["result"]["serverInfo"]
+        ntools = len(m.call("tools/list")["result"]["tools"])
+        print(f"INIT: {si['name']} {si['version']}  ({ntools} tools)\n")
+        m.notify("notifications/initialized")
+
+        results: list[bool] = []
+
+        def check(label: str, cond: bool, detail: str = "") -> None:
+            results.append(cond)
+            print(f"{'PASS' if cond else 'FAIL'}  {label}" + (f"  -- {detail}" if not cond else ""))
+
+        # ── UC1: baseline eval ──────────────────────────────────────────
+        print("-- UC1: baseline setup + eval --")
+        m.tool("tree_set_meta", {"run_name": "bench", "eval_cmd": "python eval.py",
+                                 "metric_direction": "maximize", "trunk_branch": "trunk", "cwd": CWD})
+        ev = m.tool("eval_run", {"run_name": "bench", "cmd": "python eval.py",
+                                 "split": "dev", "set_meta": "baseline", "cwd": CWD})
+        check("UC1 baseline eval ran (returncode 0)", ev.get("returncode") == 0, str(ev)[:100])
+        check("UC1 baseline score == 19.0", ev.get("score") == 19.0, str(ev.get("score")))
+        m.tool("eval_run", {"run_name": "bench", "cmd": "python eval.py",
+                            "split": "test", "set_meta": "test_baseline", "cwd": CWD})
+        tv = m.tool("tree_view", {"run_name": "bench", "fmt": "compact", "cwd": CWD})
+        check("UC1 tree records baseline=19", "baseline=19" in str(tv), str(tv)[:100])
+
+        # ── UC2: hypothesis → worktree → edit → eval → merge into trunk ─
+        print("\n-- UC2: hypothesis -> experiment -> merge (trunk, toy repo only) --")
+        m.tool("tree_add_node", {"run_name": "bench", "parent_id": "ROOT",
+                                 "hypothesis": "set LR=0.1 (peak)", "cwd": CWD})
+        wt = m.tool("worktree_create", {"run_name": "bench", "node_id": "1", "cwd": CWD})
+        wp, wb = wt["worktree"], wt["branch"]
+        check("UC2 worktree created", bool(wp), str(wt)[:100])
+        rc, _, err = exec_ctr(f"cd '{wp}' && sed -i 's/LEARNING_RATE = 0.01/LEARNING_RATE = 0.1/' solution.py && "
+                              f"git -c user.email=t@t.t -c user.name=T commit -qam 'exp: LR=0.1'")
+        check("UC2 edit+commit in worktree", rc == 0, err)
+        ev2 = m.tool("eval_run", {"run_name": "bench", "cmd": "python eval.py", "split": "test",
+                                  "set_meta": "none", "exec_cwd": wp, "cwd": CWD})
+        check("UC2 experiment score == 100.0", ev2.get("score") == 100.0, str(ev2.get("score")))
+        try:
+            m.tool("git_merge_branch", {"run_name": "bench", "node_id": "1", "source_branch": wb,
+                                        "target_branch": "trunk", "test_score": 100.0, "dry_run": True, "cwd": CWD})
+            check("UC2 dry-run merge guards pass", True)
+        except RuntimeError as e:
+            check("UC2 dry-run merge guards pass", False, str(e)[:100])
+        mrg = m.tool("git_merge_branch", {"run_name": "bench", "node_id": "1", "source_branch": wb,
+                                          "target_branch": "trunk", "test_score": 100.0,
+                                          "commit_message": "merge: LR=0.1 (19->100)", "cwd": CWD})
+        check("UC2 merge executed (trunk, toy repo)", "merged" in str(mrg).lower() or mrg.get("merged") is not False, str(mrg)[:100])
+        _, log, _ = exec_ctr(f"cd {CWD} && git --no-pager log trunk --oneline | head -3")
+        check("UC2 trunk contains the experiment commit", "LR=0.1" in log, log)
+        m.tool("tree_update_node", {"run_name": "bench", "node_id": "1", "status": "merged", "score": 100.0, "cwd": CWD})
+
+        # ── UC3: bad hypothesis → prune → report → dashboard ────────────
+        print("\n-- UC3: bad hypothesis -> prune -> report -> dashboard --")
+        m.tool("tree_add_node", {"run_name": "bench", "parent_id": "ROOT",
+                                 "hypothesis": "set LR=1.0 (overshoot)", "cwd": CWD})
+        wt2 = m.tool("worktree_create", {"run_name": "bench", "node_id": "2", "cwd": CWD})
+        wp2 = wt2["worktree"]
+        rc, _, err = exec_ctr(f"cd '{wp2}' && sed -i 's/LEARNING_RATE = 0.01/LEARNING_RATE = 1.0/' solution.py && "
+                              f"git -c user.email=t@t.t -c user.name=T commit -qam 'exp: LR=1.0'")
+        check("UC3 edit+commit bad experiment", rc == 0, err)
+        ev3 = m.tool("eval_run", {"run_name": "bench", "cmd": "python eval.py", "split": "dev",
+                                  "exec_cwd": wp2, "cwd": CWD})
+        check("UC3 bad score < baseline (19)", ev3.get("score", 999) < 19, str(ev3.get("score")))
+        m.tool("tree_prune", {"run_name": "bench", "node_id": "2", "reason": "score regressed", "cwd": CWD})
+        check("UC3 bad node pruned", True)
+        m.tool("generate_report", {"run_name": "bench", "cwd": CWD})
+        _, ls, _ = exec_ctr(f"ls {CWD}/.arbor/sessions/bench/REPORT.md 2>/dev/null && echo FOUND")
+        check("UC3 REPORT.md written in test-bench", "FOUND" in ls, ls)
+        dash = m.tool("open_dashboard", {"run_name": "bench", "cwd": CWD})
+        check("UC3 dashboard URL returned", "http" in str(dash), str(dash)[:100])
+
+        passed = sum(1 for c in results if c)
+        print(f"\n=== {passed}/{len(results)} checks passed ===")
+        return 0 if passed == len(results) else 1
+    finally:
+        m.close()
+        subprocess.run(["docker", "rm", "-f", CTR], capture_output=True)
+        shutil.rmtree(WS, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a `Dockerfile` + `docker-compose.yml` that run Arbor in a security-hardened container with **MCP-over-stdio as the default mode**. Every `arbor` subcommand is selectable via the `ARBOR_MODE` env var (`mcp` | `run` | `web` | `doctor` | `version` | `config` | `replay` | `report` | `export` | `idea-check` | `quickstart` | `benchmark` | `setup` | `install` | `uninstall` | `login`).

This lets a host coding agent (Claude Code, Codex) use Arbor's research-loop primitives (hypothesis tree, eval, worktree, merge) as an MCP tool server with zero host-side Python.

### Security posture
- non-root user (uid/gid match host so the workspace mount is writable)
- `read_only: true` rootfs; tmpfs `/home/arbor` (config + API key live in RAM, never disk)
- `cap_drop: [ALL]`, `no-new-privileges`, resource limits (`memory: 2g`, `cpus: 2.0`)
- isolated `arbor-net` bridge (no host networking); `tini` as PID 1

### Design notes
- The entrypoint generates `~/.arbor/config.yaml` from env vars when none is mounted. Config-init stdout is redirected to stderr so MCP's JSON-RPC stream on stdout stays clean.
- `arbor web` binds `127.0.0.1` only (`src/webui/server.py`); `socat` re-exposes it on `0.0.0.0:${WEB_PORT}` without host networking.
- The host GID (e.g. macOS 20 = `dialout`) is reused if it already exists, rather than failing `groupadd`.
- Installs from repo source: `pip install .[mcp]` (the `[mcp]` extra pulls the MCP SDK the default mode needs).

### Test
Ships `docker/test_mcp.py` — a self-contained integration test (spawns the container, speaks MCP over stdio, 14 assertions across 3 use cases: baseline eval → experiment+merge → prune+report) with a toy-benchmark fixture and `docker/TESTING.md`.

## Linked issue

Closes #51

## Type of change

- [x] ✨ Feature (`feat`)

## How was this tested?

```text
$ docker compose build
$ python docker/test_mcp.py
INIT: arbor 1.28.1  (12 tools)
-- UC1: baseline setup + eval --          PASS x3
-- UC2: hypothesis -> experiment -> merge  PASS x6   (merge into `trunk` only)
-- UC3: bad hypothesis -> prune -> report  PASS x5
=== 14/14 checks passed ===
```

Security confirmed inside the container: `uid=501(arbor)`, `CapEff=0000000000000000`, `NoNewPrivs=1`, rootfs read-only (`touch /` denied). The test uses a dummy API key (no tool in the loop calls the LLM) and is isolated to a throwaway toy repo — merges target only its non-protected `trunk` branch.

## Checklist

- [x] PR title follows Conventional Commits (`feat(docker): ...`).
- [x] The change is focused and reasonably small (11 files, +680).
- [x] I ran the relevant tests locally and they pass (`python docker/test_mcp.py` → 14/14).
- [x] Docs updated: `docker/README.md` (usage) + `docker/TESTING.md` (test description). The top-level READMEs don't enumerate per-field options (they point to `docs/configuration.md`), so no README change was needed.
- [x] No secrets, API keys, or tokens are included in the diff (dummy key in the test; `.env` gitignored).