### PR TITLE
docs: remove claw-code acknowledgement (Arbor is pure Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,20 +570,6 @@ src/                 # the `arbor` package
 
 ---
 
-## 🙏 Acknowledgements
-
-Arbor is built on the excellent foundation of
-[claw-code](https://github.com/ultraworkers/claw-code).
-
-claw-code is an open-source Rust reimplementation of Claude Code. It provided
-the REPL framework, tool-calling infrastructure, and cross-platform compilation
-that made Arbor's CLI possible. Huge thanks to the ultraworkers team for their
-outstanding work.
-
-🔗 claw-code: https://github.com/ultraworkers/claw-code
-
----
-
 ## 📚 Citation
 
 ```bibtex

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -454,18 +454,6 @@ src/                 # `arbor` 包
 
 ------
 
-## 🙏 致谢
-
-Arbor 构建在优秀的开源项目
-[claw-code](https://github.com/ultraworkers/claw-code) 之上。
-
-claw-code 是 Claude Code 的开源 Rust 复现，为 Arbor CLI 提供了 REPL 框架、
-工具调用基础设施和跨平台编译能力。非常感谢 ultraworkers 团队的出色工作。
-
-🔗 claw-code: https://github.com/ultraworkers/claw-code
-
-------
-
 ## 📚 引用
 
 ```bibtex


### PR DESCRIPTION
## Summary

The Acknowledgements in `README.md` and `README.zh-CN.md` claimed Arbor was *"built on"* [claw-code](https://github.com/ultraworkers/claw-code) and that claw-code *"provided the REPL framework, tool-calling infrastructure, and cross-platform compilation"* for Arbor's CLI. The codebase is pure Python (Typer + asyncio) with no Rust and no claw-code reference anywhere; claw-code is itself a Rust project with no role here. This PR **removes the entire Acknowledgements section** from both READMEs.

Diff: −26 lines, 0 insertions (14 from `README.md`, 12 from `README.zh-CN.md`).

## Linked issue

Closes #53

## Type of change

- [x] 📝 Docs (`docs`)

## How was this tested?

Doc-only change; verified the claim against the codebase first (no `.rs` / `Cargo.toml`; no `claw-code` reference in `src/`, `pyproject.toml`, `scripts/`, or git history; entry point is `arbor.cli.app:main`). Confirmed no `claw-code` / `ultraworkers` string remains anywhere in the repo after the removal.

## Checklist

- [x] PR title follows Conventional Commits (`docs: ...`).
- [x] The change is focused and small (2 files, −26/0).
- [x] Both READMEs updated (`README.md` and `README.zh-CN.md`).
- [x] No secrets, API keys, or tokens in the diff.