### PR TITLE
fix(docs): restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,15 +607,15 @@ outstanding work.
 <picture>
   <source
     media="(prefers-color-scheme: dark)"
-    srcset="https://api.star-history.com/svg?repos=RUC-NLPIR/Arbor&type=Date&theme=dark"
+    srcset="https://star-history.dera.page/svg?repos=RUC-NLPIR/Arbor&type=Date&theme=dark"
   />
   <source
     media="(prefers-color-scheme: light)"
-    srcset="https://api.star-history.com/svg?repos=RUC-NLPIR/Arbor&type=Date"
+    srcset="https://star-history.dera.page/svg?repos=RUC-NLPIR/Arbor&type=Date"
   />
   <img
     alt="Star History Chart"
-    src="https://api.star-history.com/svg?repos=RUC-NLPIR/Arbor&type=Date"
+    src="https://star-history.dera.page/svg?repos=RUC-NLPIR/Arbor&type=Date"
   />
 </picture>
 


### PR DESCRIPTION
The current Star History chart is broken and no longer renders correctly. Update the README chart image URLs so the project star history is available again.