### PR TITLE
fix(coordinator): emit one IDEA_PRUNED event per cascaded node

### DIFF
--- a/src/coordinator/idea_tree.py
+++ b/src/coordinator/idea_tree.py
@@ -287,6 +287,8 @@ class IdeaTree:
         if node is None:
             raise ValueError(f"Node {node_id!r} not found")
 
+        pruned_ids: list[str] = []
+
         def _prune(nid: str) -> None:
             n = self._nodes.get(nid)
             if n is None:
@@ -294,13 +296,16 @@ class IdeaTree:
             n.status = "pruned"
             if reason and nid == node_id:
                 n.insight = (n.insight + f"\n[Pruned: {reason}]").strip()
+            pruned_ids.append(nid)
             for child_id in n.children_ids:
                 _prune(child_id)
 
         _prune(node_id)
         self.save()
         from ..events.types import IDEA_PRUNED
-        self.bus.emit(IDEA_PRUNED, {"node_id": node_id, "reason": reason})
+        # One event per pruned node: every idea.* consumer keys off a single node_id.
+        for nid in pruned_ids:
+            self.bus.emit(IDEA_PRUNED, {"node_id": nid, "reason": reason})
 
     # ── Async-safe mutations (for parallel executor scenarios) ───────
 

--- a/tests/test_idea_tree.py
+++ b/tests/test_idea_tree.py
@@ -186,6 +186,51 @@ def test_prune_node_recurses_into_subtree() -> None:
     assert "dead end" not in t.get_node("1.1").insight
 
 
+# ── prune cascade -> event contract (#62) ──────────────────────────────
+
+def test_prune_node_emits_one_event_per_pruned_node() -> None:
+    from arbor.events.bus import EventBus
+
+    bus = EventBus()
+    t = IdeaTree(Node(id="ROOT", parent_id=None, depth=0), bus=bus)
+    _child(t, "ROOT")          # "1"
+    _child(t, "1")             # "1.1"
+    _child(t, "1.1")           # "1.1.1"
+    _child(t, "ROOT")          # "2", untouched sibling, must not fire
+
+    received: list[str] = []
+    bus.on("idea.pruned", lambda e: received.append(e.data["node_id"]))
+
+    t.prune_node("1", reason="dead end")
+
+    assert sorted(received) == ["1", "1.1", "1.1.1"]
+
+
+def test_prune_cascade_updates_stats_and_dashboard_for_every_descendant() -> None:
+    from arbor.cli.run_state import RunState
+    from arbor.events import types as ev
+    from arbor.events.bus import EventBus
+    from arbor.events.subscribers.stats_collector import StatsCollector
+
+    bus = EventBus()
+    stats = StatsCollector()
+    stats.attach(bus)
+    run_state = RunState()
+    bus.on(ev.IDEA_PROPOSED, run_state.on_idea_proposed)
+    bus.on(ev.IDEA_PRUNED, run_state.on_idea_pruned)
+
+    t = IdeaTree(Node(id="ROOT", parent_id=None, depth=0), bus=bus)
+    _child(t, "ROOT")          # "1"
+    _child(t, "1")             # "1.1"
+    _child(t, "1.1")           # "1.1.1"
+
+    t.prune_node("1", reason="dead end")
+
+    assert stats.stats.ideas_pruned == 3
+    assert {run_state.ideas[nid].status for nid in ("1", "1.1", "1.1.1")} == {"pruned"}
+    assert run_state.ideas_pruned == 3
+
+
 # ── next_child_id ────────────────────────────────────────────────────
 
 def test_next_child_id_sequence_and_nesting() -> None:


### PR DESCRIPTION
## Summary

`IdeaTree.prune_node()` recursively sets `status = "pruned"` on the target node and every
descendant (`_prune()`, called on `node_id` then each `child_id`), but after the recursion
finished it emitted exactly one `IDEA_PRUNED` event, for `node_id` only.

Every consumer keys off a single `node_id` per event: `StatsCollector._inc_pruned` increments
a counter by one per event, and `RunState.on_idea_pruned` (the source for the TUI header and,
via `webui/snapshot.py`, the WebUI tree) updates the record for the one `node_id` in the event
payload. So cascaded descendants kept their pre-prune status ("proposed") in both places even
though `idea_tree.json` on disk already marked them pruned, which is the TUI/WebUI count
mismatch reported in #62.

Fix: collect the ids mutated during the cascade and emit one `IDEA_PRUNED` event per id instead
of one for the whole cascade. Each descendant now carries the same `reason` as the node the
caller pruned, since it was pruned as a direct consequence of that call.

## Linked issue

Closes #62

## Type of change

- [x] Bug fix (`fix`)

## How was this tested?

- New regression test asserts the event set matches every mutated node id (not just the
  target) and that an untouched sibling emits nothing; both fail against unpatched
  `prune_node` and pass after the fix.
- A second test drives `StatsCollector` and `RunState` end to end through the real event bus
  and asserts the pruned count and every descendant's status.
- Full `pytest` (154 files) and `ruff check src/ tests/` both pass clean on Python 3.10 and
  3.13, in a clean Docker container, with dependency versions pinned from `uv.lock`.

```text
python -m pytest tests/ -q
python -m ruff check src/ tests/
```

Not checked: the live TUI/WebUI rendering itself, since neither has a scripted test harness in
this repo; the assertion is on the state each of them consumes (`RunState`/`StatsCollector`).

## Checklist

- [x] PR title follows Conventional Commits (e.g. `fix(config): ...`).
- [x] The change is focused and reasonably small.
- [x] I ran the relevant tests locally (`python tests/test_*.py`) and they pass.
- [x] Docs / examples updated if behavior or config changed. (not applicable, no docs describe this event contract)
- [x] No secrets, API keys, or tokens are included in the diff.
